### PR TITLE
Move the common schema into a central file

### DIFF
--- a/meta/structure.graphql
+++ b/meta/structure.graphql
@@ -1,0 +1,103 @@
+type Query {
+  allLinks(filter: LinkFilter, orderBy: LinkOrderBy, skip: Int, first: Int): [Link!]!
+  _allLinksMeta: _QueryMeta!
+}
+
+type Mutation {
+  signinUser(email: AUTH_PROVIDER_EMAIL): SigninPayload!
+  createUser(name: String!, authProvider: AuthProviderSignupData!): User
+  createLink(description: String!, url: String!, postedById: ID): Link
+  createVote(linkId: ID, userId: ID): Vote
+}
+
+type Subscription {
+  Link(filter: LinkSubscriptionFilter): LinkSubscriptionPayload
+  Vote(filter: VoteSubscriptionFilter): VoteSubscriptionPayload
+}
+
+interface Node {
+  id: ID!
+}
+
+type User implements Node {
+  id: ID! @isUnique
+  createdAt: DateTime!
+  name: String!
+  links: [Link!]! @relation(name: "UsersLinks")
+  votes: [Vote!]! @relation(name: "UsersVotes")
+  email: String @isUnique
+  password: String
+}
+
+type Link implements Node {
+  id: ID! @isUnique
+  createdAt: DateTime!
+  url: String!
+  description: String!
+  postedBy: User! @relation(name: "UsersLinks")
+  votes: [Vote!]! @relation(name: "VotesOnLink")
+}
+
+type Vote implements Node {
+  id: ID! @isUnique
+  createdAt: DateTime!
+  user: User! @relation(name: "UsersVotes")
+  link: Link! @relation(name: "VotesOnLink")
+}
+
+input AuthProviderSignupData {
+  email: AUTH_PROVIDER_EMAIL
+}
+
+input AUTH_PROVIDER_EMAIL {
+  email: String!
+  password: String!
+}
+
+input LinkSubscriptionFilter {
+  mutation_in: [_ModelMutationType!]
+}
+
+input VoteSubscriptionFilter {
+  mutation_in: [_ModelMutationType!]
+}
+
+input LinkFilter {
+  OR: [LinkFilter!]
+  description_contains: String
+  url_contains: String
+}
+
+type SigninPayload {
+  token: String
+  user: User
+}
+
+type LinkSubscriptionPayload {
+  mutation: _ModelMutationType!
+  node: Link
+  updatedFields: [String!]
+}
+
+type VoteSubscriptionPayload {
+  mutation: _ModelMutationType!
+  node: Vote
+  updatedFields: [String!]
+}
+
+enum LinkOrderBy {
+  createdAt_ASC
+  createdAt_DESC
+}
+
+enum _ModelMutationType {
+  CREATED
+  UPDATED
+  DELETED
+}
+
+type _QueryMeta {
+  count: Int!
+}
+
+scalar DateTime


### PR DESCRIPTION
It would be good all implementations to share a common schema. Currently the schema is listed in all `meta/structure/**.md`. 

I moved it into a central file, so everybody can reference it.