### PR TITLE
Simple fix to avoid horizontal scroll on the home page due to particles overflowing.

### DIFF
--- a/src/components/home/Intro.tsx
+++ b/src/components/home/Intro.tsx
@@ -19,6 +19,7 @@ class Intro extends React.Component<Props, null> {
       <section className="intro">
         <div className="particles">
           <Particles
+            style={ { maxWidth: '100%' } }
             width={`${typeof window !== 'undefined' && window.innerWidth || 1000}`}
             params={
               {


### PR DESCRIPTION
This fixes a horizontal scroll happening because of the particles component on the home page, on a 1368 screen resolution.

The whole home page is not mobile-friendly, though. I'll fire an issue about that.