### PR TITLE
Fixes horizontal scroll on the tutorial page.

### DIFF
--- a/src/components/Tutorials/Sidebar.tsx
+++ b/src/components/Tutorials/Sidebar.tsx
@@ -73,7 +73,6 @@ export default class Sidebar extends React.Component<Props, {}> {
               rgba(245, 245, 245, 0)
             );
             height: 38px;
-            width: 100%;
           }
           .sidebar :global(.plus) {
             background-color: rgb(245, 245, 245);


### PR DESCRIPTION
_Similar to #62_ 

There is a horizontal happening on Chrome/Linux due to a decorative element with `left: 1px; width: 100%`. The element overflows a single pixel, but that on Linux bring the whole beautiful scroll bar to the scene.

**Update:** the decorative element will continue to work for it has a `right: 1px` style also ;)

I'll continue looking for this kind of bugs, for it seems the developing team on the project are not using Linux and therefor not catching this minor issues.