### PR TITLE
Remove instruction to use install generator

### DIFF
--- a/content/backend/graphql-ruby/3-mutations.md
+++ b/content/backend/graphql-ruby/3-mutations.md
@@ -9,7 +9,7 @@ Setting up mutations is as easy as queries, following a very similar process.
 
 All [GraphQL mutations](http://graphql.org/learn/queries/#mutations) start from a root type called **Mutation**.
 
-This type is **not** auto generated. You'll need to generate it using `rails generate graphql:install`.
+This type is **not** auto generated.
 
 <Instruction>
 


### PR DESCRIPTION
At this moment, the install generator does not yet generate the mutation type. Removes the instruction to use the install generator.