### PR TITLE
Firefox bug: all endpoints point to introduction!

### DIFF
--- a/content/backend/graphql-js/0-introduction.md
+++ b/content/backend/graphql-js/0-introduction.md
@@ -1,3 +1,8 @@
+`With FIREFOX every endpoint such as: getting started, quires, mutations connectors, and so on go to the introduction page.`
+* So basically, in firefox, you cannot do the tutorials for these sections.
+* In Chrome it works.
+
+
 ---
 title: Introduction
 question: Which of these is a requirement for GraphQl servers?


### PR DESCRIPTION
There is a Firefox error, at least, with the Grpahql-js tutorials. I tried end Chrome and it works. In Firefox, over and over again the bug continues.

I am not sure where to put this information. It would be nice if I knew how to find the code so I can edit it. This takes me a lot of time to write you guys, so please respond back with a proper way to let you know of these errors (so far found 2 and did 2 pull requests). 

Personally, I would rather find the code and do the editing myself so I can get some decent contributions. :)