### PR TITLE
Update allLinks example path

### DIFF
--- a/content/backend/graphql-ruby/7-filtering.md
+++ b/content/backend/graphql-ruby/7-filtering.md
@@ -98,7 +98,7 @@ This resolver contains all logic related to find links. Over time you can more r
 
 Use `LinksSearch` for finding links:
 
-```ruby(path=".../graphql-ruby/app/graphql/resolvers/links_search.rb")
+```ruby(path=".../graphql-ruby/app/graphql/types/query_type.rb")
 Types::QueryType = GraphQL::ObjectType.define do
   name 'Query'
 


### PR DESCRIPTION
Looks like the path for updating the `allLinks` query type is incorrect. This updates it to the correct path