### PR TITLE
Fix generated link ids in the graphql.js tutorial

### DIFF
--- a/content/backend/graphql-js/3-mutations.md
+++ b/content/backend/graphql-js/3-mutations.md
@@ -35,7 +35,7 @@ module.exports = {
   },
   Mutation: {
     createLink: (_, data) => {
-      const newLink = Object.assign({id: links.length}, data);
+      const newLink = Object.assign({id: links.length + 1}, data);
       links.push(newLink);
       return newLink;
     }


### PR DESCRIPTION
As was pointed out by @neighborhood999 (thanks a lot!), the id generation was missing a `+ 1` since it's starting from 1, not from 0. Fixing it here.