### PR TITLE
Add instruction for importing Redirect component

### DIFF
--- a/content/frontend/react-apollo/9-pagination.md
+++ b/content/frontend/react-apollo/9-pagination.md
@@ -38,6 +38,18 @@ render() {
 
 </Instruction>
 
+Make sure to import the Redirect component, so you don't get any errors.
+
+<Instruction>
+
+Open `App.js` and update the router import on the top of the file:
+
+```js(path=".../hackernews-react-apollo/src/components/App.js")
+import { Switch, Route, Redirect } from 'react-router-dom'
+```
+
+</Instruction>
+
 
 You now added two new routes: `/top` and `/new/:page`. The second one reads the value for `page` from the url so that this information is available inside the component that's rendered, here that's `LinkList`.
 


### PR DESCRIPTION
There is no instructions for importing the Redirect component from `react-router-dom`. I got this error while following the tutorial, so I think others may face the same issue.