### PR TITLE
Fix data type mismatch in Mutation declaration

### DIFF
--- a/content/graphql/basics/2-core-concepts.md
+++ b/content/graphql/basics/2-core-concepts.md
@@ -263,7 +263,7 @@ Similarly, for the `createPerson`-mutation, we’ll have to add a root field to 
 
 ```graphql(nocopy)
 type Mutation {
-  createPerson(name: String!, age: String!): Person!
+  createPerson(name: String!, age: Int!): Person!
 }
 ```
 
@@ -285,7 +285,7 @@ type Query {
 }
 
 type Mutation {
-  createPerson(name: String!, age: String!): Person!
+  createPerson(name: String!, age: Int!): Person!
 }
 
 type Subscription {


### PR DESCRIPTION
Changed `String!` to `Int!` for the **age** parameter of **Mutation** declaration in schema.