### PR TITLE
ISSUE-146 Update video id for React+Relay 3-Mutations-Creating-Links

### DIFF
--- a/content/frontend/react-relay/3-mutations-creating-links.md
+++ b/content/frontend/react-relay/3-mutations-creating-links.md
@@ -4,11 +4,11 @@ description: In this chapter, you'll learn how you can send mutations with Relay
 question: What's one of the major changes of Relay Modern compared to Relay Classic?
 answers: ["Detailled documentation and many code samples", "An imperative and more predictible mutation API", "Declaring data dependencies as fragments alongisde React components", "Relay Modern also includes a new server component"]
 correctAnswer: 1
-videoId: x9xtQdWcKMc
+videoId: eIsctkVmq4Y
 duration: 10
 ---
 
-In this section, you'll learn how you can send mutations with Relay. 
+In this section, you'll learn how you can send mutations with Relay.
 
 
 ### Preparing the React components
@@ -180,7 +180,7 @@ To test the mutation, you now need to render the `CreateLink` component inside t
 
 <Instruction>
 
-Open `App.js` and first import the `CreateLink` component on top of the file: 
+Open `App.js` and first import the `CreateLink` component on top of the file:
 
 ```js(path=".../hackernews-react-relay/src/components/App.js")
 import CreateLink from './CreateLink'
@@ -191,7 +191,7 @@ import CreateLink from './CreateLink'
 
 <Instruction>
 
-Next, still `App.js` update `render` to look as follows: 
+Next, still `App.js` update `render` to look as follows:
 
 ```js(path=".../hackernews-react-relay/src/components/App.js")
 render() {


### PR DESCRIPTION
**Issue:** https://github.com/howtographql/howtographql/issues/146

## What
- Update the `videoId` for `/react-relay/3-mutations-creating-links.md` to match the [new video](https://www.youtube.com/watch?v=eIsctkVmq4Y)
- Trim trailing whitespace _(text editor setting)_

## Why
The old link was broken, likely due to someone uploading a new version of the video