### PR TITLE
Fixes small typo in 2-queries.md

### DIFF
--- a/content/backend/graphql-js/2-queries.md
+++ b/content/backend/graphql-js/2-queries.md
@@ -92,7 +92,7 @@ const {graphqlExpress, graphiqlExpress} = require('graphql-server-express');
 // ...
 
 app.use('/graphiql', graphiqlExpress({
-  endpointURL: '/graphql',
+  endpointURL: '/graphiql',
 }));
 ```
 


### PR DESCRIPTION
The endpoint should be `/graphiql`, not `/graphql`.