### PR TITLE
Rename graphql-server- dependencies to apollo-server-

### DIFF
--- a/content/backend/graphql-js/1-getting-started.md
+++ b/content/backend/graphql-js/1-getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
 question: Which of the following packages allows converting a string in the GraphQL Schema Definition Language into a schema object?
-answers: ["body-parser", "graphql-tools", "graphql-server-express", "express"]
+answers: ["body-parser", "graphql-tools", "apollo-server-express", "express"]
 correctAnswer: 1
 description: Setup your GraphQL server and run it for the first time
 ---
@@ -47,7 +47,7 @@ It's time to start creating your project.
 **Step 3**: Install the following dependencies:
 
 ```bash(path=".../hackernews-graphql-js")
-npm install -save express body-parser graphql-server-express graphql-tools graphql
+npm install -save express body-parser apollo-server-express graphql-tools graphql
 ```
 
 </Instruction>
@@ -92,7 +92,7 @@ const bodyParser = require('body-parser');
 
 // This package will handle GraphQL server requests and responses
 // for you, based on your schema.
-const {graphqlExpress} = require('graphql-server-express');
+const {graphqlExpress} = require('apollo-server-express');
 
 const schema = require('./schema');
 

--- a/content/backend/graphql-js/2-queries.md
+++ b/content/backend/graphql-js/2-queries.md
@@ -80,14 +80,14 @@ module.exports = makeExecutableSchema({typeDefs, resolvers});
 
 It's time to test what you've done so far! For this you'll use [GraphiQL](https://github.com/graphql/graphiql), as was said before.
 
-It's super easy to setup. You're going to use the same `graphql-server-express` package for this.
+It's super easy to setup. You're going to use the same `apollo-server-express` package for this.
 
 <Instruction>
 
 Just add these lines to `src/index.js`:
 
 ```js(path=".../hackernews-graphql-js/src/index.js")
-const {graphqlExpress, graphiqlExpress} = require('graphql-server-express');
+const {graphqlExpress, graphiqlExpress} = require('apollo-server-express');
 
 // ...
 

--- a/content/backend/graphql-js/4-connectors.md
+++ b/content/backend/graphql-js/4-connectors.md
@@ -64,7 +64,7 @@ Go back to the main `src/index.js` file and change it to be like this:
 ```js{6-30}(path=".../hackernews-graphql-js/src/index.js")
 const express = require('express');
 const bodyParser = require('body-parser');
-const {graphqlExpress, graphiqlExpress} = require('graphql-server-express');
+const {graphqlExpress, graphiqlExpress} = require('apollo-server-express');
 const schema = require('./schema');
 
 // 1

--- a/content/backend/graphql-js/5-authentication.md
+++ b/content/backend/graphql-js/5-authentication.md
@@ -158,7 +158,7 @@ Mutation: {
 
 With the token that the `signinUser` mutation provides, apps can authenticate subsequent requests by passing it via the `Authorization` header. The GraphQL server should be able to get the contents from this header on each request, detect what user it's related to, and pass this information down to the resolvers.
 
-As you've already seen before, the best place to put data shared between resolvers is in the context object. You'll need that object to be different in every request now though, since each one may be from a different user. Thankfully, `graphql-server-express` allows that too.
+As you've already seen before, the best place to put data shared between resolvers is in the context object. You'll need that object to be different in every request now though, since each one may be from a different user. Thankfully, `apollo-server-express` allows that too.
 
 <Instruction>
 


### PR DESCRIPTION
With [the release of Apollo Server 1.0](https://dev-blog.apollodata.com/apollo-server-1-0-a-graphql-server-for-all-node-js-frameworks-2b37d3342f7c), we've renamed the packages (back...) to `apollo-server-`. Although we'll continue to publish `graphql-server-` packages for a little while, tutorials should upgrade to the new naming.

Closes apollographql/apollo-server#480.