### PR TITLE
Fix typo in graphql-js tutorial npm installation command

### DIFF
--- a/content/backend/graphql-js/1-getting-started.md
+++ b/content/backend/graphql-js/1-getting-started.md
@@ -47,7 +47,7 @@ It's time to start creating your project.
 **Step 3**: Install the following dependencies:
 
 ```bash(path=".../hackernews-graphql-js")
-npm install -save express body-parser apollo-server-express graphql-tools graphql
+npm install --save express body-parser apollo-server-express graphql-tools graphql
 ```
 
 </Instruction>


### PR DESCRIPTION
This typo was reported by @nagman at https://github.com/howtographql/howtographql/issues/156. Thanks a lot!