### PR TITLE
Fix typo in file reference

### DIFF
--- a/content/frontend/react-relay/5-authentication.md
+++ b/content/frontend/react-relay/5-authentication.md
@@ -537,7 +537,7 @@ Secondly, you should also include the information about the user in the mutation
 
 <Instruction>
 
-Sill in `CreateLinkMutation.js`, update the definition of `mutation` like so:
+Still in `CreateLinkMutation.js`, update the definition of `mutation` like so:
 
 ```js{9-11}(path=".../hackernews-react-relay/src/mutations/CreateLinkMutation.js")
 const mutation = graphql`

--- a/content/frontend/react-relay/5-authentication.md
+++ b/content/frontend/react-relay/5-authentication.md
@@ -539,7 +539,7 @@ Secondly, you should also include the information about the user in the mutation
 
 Sill in `CreateLinkMutation.js`, update the definition of `mutation` like so:
 
-```js{9-11}(path=".../hackernews-react-relay/src/components/CreateLink.js")
+```js{9-11}(path=".../hackernews-react-relay/src/mutations/CreateLinkMutation.js")
 const mutation = graphql`
   mutation CreateLinkMutation($input: CreateLinkInput!) {
     createLink(input: $input) {


### PR DESCRIPTION
In react-relay 5-Authentication, the path reference to the change in the `CreateLinkMutation` is incorrect. It should be a reference to the mutation file rather than the `CreateLink` component