### PR TITLE
Fix few typos in react-apollo frontend tutorial

### DIFF
--- a/content/frontend/react-apollo/3-mutations-creating-links.md
+++ b/content/frontend/react-apollo/3-mutations-creating-links.md
@@ -80,7 +80,7 @@ This is a standard setup for a React component with two `input` fields where use
 
 But how can you now actually send the mutation? Let's follow the three steps from before.
 
-First you need to define the mutation in your JavaScript code and wrap your component with the `graphl` container. You'll do that in a similar way as with the query before.
+First you need to define the mutation in your JavaScript code and wrap your component with the `graphql` container. You'll do that in a similar way as with the query before.
 
 <Instruction>
 

--- a/content/frontend/react-apollo/4-routing.md
+++ b/content/frontend/react-apollo/4-routing.md
@@ -27,7 +27,7 @@ yarn add react-router-dom
 
 ### Create a Header
 
-Before you're moving on to configure the different routes for your application, you need to create a `Header` component that users can use to navigate to between the different parts of your app.
+Before you're moving on to configure the different routes for your application, you need to create a `Header` component that users can use to navigate between the different parts of your app.
 
 <Instruction>
 

--- a/content/frontend/react-apollo/9-pagination.md
+++ b/content/frontend/react-apollo/9-pagination.md
@@ -244,8 +244,8 @@ _nextPage = () => {
 _previousPage = () => {
   const page = parseInt(this.props.match.params.page, 10)
   if (page > 1) {
-    const nextPage = page - 1
-    this.props.history.push(`/new/${nextPage}`)
+    const previousPage = page - 1
+    this.props.history.push(`/new/${previousPage}`)
   }
 }
 ```


### PR DESCRIPTION
1. Change `graphl` to `graphql` in **3-mutations**
2. Fix minor grammatical error in **4-routing.md**
3. Change `nextPage` to `previousPage` in the `_previousPage` function for **9-pagination.md**