### PR TITLE
Hotfix/subscription endpoint and typos

### DIFF
--- a/content/frontend/react-relay/7-subscriptions.md
+++ b/content/frontend/react-relay/7-subscriptions.md
@@ -88,7 +88,7 @@ const fetchQuery = (operation, variables) => {
 const setupSubscription = (config, variables, cacheConfig, observer) => {
   const query = config.text
 
-  const subscriptionClient = new SubscriptionClient('wss://subscriptions.graph.cool/v1/__PROJECT_ID__', {reconnect: true})
+  const subscriptionClient = new SubscriptionClient('wss://subscriptions.__REGION__.graph.cool/v1/__PROJECT_ID__', {reconnect: true})
   subscriptionClient.subscribe({query, variables}, (error, result) => {
     observer.onNext({data: result})
   })
@@ -103,10 +103,12 @@ const network = Network.create(fetchQuery, setupSubscription)
 Let's quickly understand what's going on there:
 
 1. Instead of passing a closure directly into `Network.create()`, you just pull out the code of that closure and store it in a variable called `fetchQuery`. Note that you'll have to replace `__PROJECT_ID__` again with your actual project ID.  
-2. Here you define the second function called `setupSubscription` that the `Network` needs in order to be able to talk to the subscriptions endpoint. You're using the `SubscriptionClient` in that function to initiate and maintain a connection to the given endpoint. The `config` that's passed into the function carrys the subscription query which determines what event the client wants to subscribe to and what data it wants to receive. Note that again you need to replace the placeholder for `__PROJECT_ID__` with the actual ID of your Graphcool project.
+2. Here you define the second function called `setupSubscription` that the `Network` needs in order to be able to talk to the subscriptions endpoint. You're using the `SubscriptionClient` in that function to initiate and maintain a connection to the given endpoint. The `config` that's passed into the function carries the subscription query which determines what event the client wants to subscribe to and what data it wants to receive. Note that again you need to replace the placeholder for `__PROJECT_ID__` with the actual ID of your Graphcool project. Also, you need to replace the placeholder for `__REGION__` with the AWS region that your graphcool API endpoint is served from.
 3. Finally, we take `fetchQuery` (which is the same code as before but stored in a variable) and `setupSubscription` and use them to create the `Network`, which then will be used to instantiate the Relay `Environment`.
 
 > If you're not sure what your Graphcool project ID is that you need to replace the `__PROJECT_ID__`, you can open `project.graphcool` and check its frontmatter or execute `graphcool endpoints` in a terminal to see the endpoints for the Relay API and Subscriptions API.
+
+> To find the `__REGION__` your endpoint is served from, go to your Graphcool console. Click the **Endpoints**-button in the bottom-left corner, go to `Subscriptions API` and replace `__REGION__` with the region mentioned there (example: 'wss://subscriptions.`ap-northeast-1`.graph.cool/v1/__PROJECT_ID__')
 
 <Instruction>
 

--- a/content/frontend/react-relay/8-pagination.md
+++ b/content/frontend/react-relay/8-pagination.md
@@ -137,7 +137,7 @@ export default createPaginationContainer(LinkList,
       }
     `,
   },
-  { }
+  { // ... this will be added soon }
 )
 ```
 
@@ -277,7 +277,7 @@ import {ITEMS_PER_PAGE} from '../constants'
 
 </Instruction>
 
-All right - you're almost there! The last thing you need to is actually calling Relay's `loadMore` function to fetch the next chunk of links from the server.
+All right - you're almost there! The last thing you need is actually calling Relay's `loadMore` function to fetch the next chunk of links from the server.
 
 <Instruction>  
 


### PR DESCRIPTION
**Bug:** The Subscriptions API endpoint as displayed in terminal on executing `graphcool endpoints` doesn't work. It is missing the AWS region the endpoint is served from.

**Fix:** Provide instructions on how to add __REGION__ field to the Subscriptions API endpoint. 

**Misc:** Add filler code (`... this will be added soon`) that is referred to later in the instructions. Also fix some typos.