### PR TITLE
Remove unused Redirect import

### DIFF
--- a/content/frontend/react-apollo/4-routing.md
+++ b/content/frontend/react-apollo/4-routing.md
@@ -103,7 +103,7 @@ Add the following statement to the top of the file:
 
 ```js(path=".../hackernews-react-apollo/src/components/App.js")
 import Header from './Header'
-import { Switch, Route, Redirect } from 'react-router-dom'
+import { Switch, Route } from 'react-router-dom'
 ```
 
 </Instruction>


### PR DESCRIPTION
`Redirect` is not used until Part 9 - Pagination so I would suggest removing this here to avoid the `no-unused-vars` warning.

You already direct the user to import the `Redirect` component in `9-pagination.md` on line 46 so it hasn't been forgotten.