### PR TITLE
[Backend][Ruby][Chapter][4]  Fix copy for Resolvers::SignInUser and update CreateLinkTest

### DIFF
--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -452,7 +452,7 @@ end
 
 <Instruction>
 
-Finally update `CreateLink` test:
+Next, update `CreateLink` test:
 
 ```ruby(path=".../graphql-ruby/test/resolvers/create_link_test.rb")
 require 'test_helper'

--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -478,6 +478,7 @@ class Resolvers::CreateLinkTest < ActiveSupport::TestCase
     assert_equal result.user, user
   end
 end
+```
 
 </Instruction>
 

--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -358,6 +358,7 @@ class Resolvers::SignInUser < GraphQL::Function
     crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base.byteslice(0..31))
     token = crypt.encrypt_and_sign("user-id:#{ user.id }")
 
+    ctx[:session] = {}
     ctx[:session][:token] = token
 
     # ...code
@@ -446,6 +447,37 @@ class Resolvers::CreateLink < GraphQL::Function
   end
 end
 ```
+
+</Instruction>
+
+<Instruction>
+
+Finally update `CreateLink` test:
+
+```ruby(path=".../graphql-ruby/test/resolvers/create_link_test.rb")
+require 'test_helper'
+
+class Resolvers::CreateLinkTest < ActiveSupport::TestCase
+  def perform(args = {}, context = {})
+    Resolvers::CreateLink.new.call(nil, args, context)
+  end
+
+  test 'creating new link' do
+    user = User.create!(name: 'test',
+                        email: 'test@email.com',
+                        password: 'test')
+
+    result = perform(
+      { description: 'description', url: 'http://example.com' },
+      current_user: user
+    )
+
+    assert result.persisted?
+    assert_equal result.description, 'description'
+    assert_equal result.url, 'http://example.com'
+    assert_equal result.user, user
+  end
+end
 
 </Instruction>
 


### PR DESCRIPTION
This PR includes the following fixes:

- the `Resolvers::SignInUser#call` wasn't properly setting the token

   change 

   ```ruby
   ctx[:session][:token] = token
   ```

   Note:  The parent key, `:session`, wasn't set and trying to set `:token` would generate the following
               error:  `ActiveRecord::RecordInvalid (Validation failed: User must exist):`

   to

   ```ruby
    ctx[:session] = {}
    ctx[:session][:token] = token
    ```
       
- update the `CreateLinkTest` to properly set the user within the context
