### PR TITLE
don't add duplicate answers to answerIndeces

### DIFF
--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -209,6 +209,12 @@ class Quiz extends React.Component<Props & QuizState, {}> {
 
   private handleAnswerClick = i => {
     const { path } = this.props
+    const reaction = this.props.quizReactions[path] || defaultReaction
+    const { answeredCorrectly } = reaction
+    const answerIndeces = reaction.answerIndeces || []
+    if (answeredCorrectly || answerIndeces.includes(i))  {
+      return
+    }
     this.props.addAnswer(path, i)
     if (this.props.correctAnswerIndex === i) {
       this.props.answerCorrectly(path)


### PR DESCRIPTION
Currently clicking on an answer for a question results in the index for that answer being appended to the answerIndeces array for that question every time.

This is an issue because later on the score for that question is calculated as 5 - len(answerIndeces). So users can get a negative score on a question because they clicked on a wrong answer twice.

Also, it doesn't make sense to allow users to add on to their incorrect answer count once they have already answered the question correctly.

The proposed fix prevents handleAnswerClick from adding indexes to answerIndeces if the question has already been answered correctly or the index is already in answerIndeces.