### PR TITLE
The src of LinkList has been fixed

### DIFF
--- a/content/frontend/react-apollo/2-queries-loading-links.md
+++ b/content/frontend/react-apollo/2-queries-loading-links.md
@@ -92,7 +92,7 @@ To complete the setup, open `App.js` and replace the current contents with the f
 
 ```js(path=".../hackernews-react-apollo/src/components/App.js")
 import React, { Component } from 'react'
-import LinkList from './LinkList'
+import LinkList from './components/LinkList'
 
 class App extends Component {
   render() {


### PR DESCRIPTION
LinkList component is not in the working directory (`/src`), but in the `/src/components` directory.