### PR TITLE
Fix missing import in code sample

### DIFF
--- a/content/backend/graphql-python/9-relay.md
+++ b/content/backend/graphql-python/9-relay.md
@@ -34,7 +34,7 @@ import django_filters
 from graphene_django import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 
-from links.models import Link
+from links.models import Link, Vote
 from users.schema import get_user
 
 


### PR DESCRIPTION
I copy/paste the code and I got an error when I run the server. The Vote model was missing in import in code sample for links/schema_relay.py file.