### PR TITLE
Put back the "beginner's choice" as the default

### DIFF
--- a/src/components/Tutorials/TutorialChooser.tsx
+++ b/src/components/Tutorials/TutorialChooser.tsx
@@ -19,7 +19,7 @@ export default class TutorialChooser extends React.Component<Props, State> {
     super(props)
 
     this.state = {
-      selectedIndex: 4,
+      selectedIndex: 5,
     }
   }
 


### PR DESCRIPTION
I think this got bumped over when the Vue + Apollo tutorial was introduced!