### PR TITLE
Lock subscriptions-transport-ws version to 0.8.3 for now

### DIFF
--- a/content/frontend/vue-apollo/8-subscriptions.md
+++ b/content/frontend/vue-apollo/8-subscriptions.md
@@ -24,7 +24,7 @@ Go ahead and add this dependency to your app first.
 Open a terminal and navigate to the project's root directory. Then execute the following command:
 
 ```bash
-npm install --save subscriptions-transport-ws
+npm install --save subscriptions-transport-ws@0.8.3
 ```
 
 </Instruction>


### PR DESCRIPTION
This fixes #226 until a significant revision using apollo-client 2.0 can be made