### PR TITLE
[backend/graphql.js]: Add how to pass context to graphql.js subscription server

### DIFF
--- a/content/backend/graphql-js/9-subscriptions.md
+++ b/content/backend/graphql-js/9-subscriptions.md
@@ -153,12 +153,27 @@ const PORT = 3000;
 const server = createServer(app);
 server.listen(PORT, () => {
   SubscriptionServer.create(
-    {execute, subscribe, schema},
+    {
+      execute,
+      subscribe,
+      schema,
+      onConnect() {
+        const dummyReq = {
+          headers: {
+            authorization: 'bearer token-foo@bar.com',
+          },
+        };
+        return buildOptions(dummyReq).then(({ context }) => {
+          return context; // This context object is passed to all resolvers.
+        });
+    },
     {server, path: '/subscriptions'},
   );
   console.log(`Hackernews GraphQL server running on port ${PORT}.`)
 });
 ```
+
+If the return value of `onConnect` function is an object then its elements will be added to the `context` which will be used by all resolvers. We are generating this context by using our existing `buildOptions` function and we are passing a dummy http request object with `authorization` header because `buildOptions` function expects http request object as first argument. For production-ready apps can pass authorization token from client side and detect current user as mentioned in this **[guide](http://dev.apollodata.com/tools/graphql-subscriptions/authentication.html)**.
 
 </Instruction>
 

--- a/content/backend/graphql-js/9-subscriptions.md
+++ b/content/backend/graphql-js/9-subscriptions.md
@@ -173,7 +173,7 @@ server.listen(PORT, () => {
 });
 ```
 
-If the return value of `onConnect` function is an object then its elements will be added to the `context` which will be used by all resolvers. We are generating this context by using our existing `buildOptions` function and we are passing a dummy http request object with `authorization` header because `buildOptions` function expects http request object as first argument. For production-ready apps can pass authorization token from client side and detect current user as mentioned in this **[guide](http://dev.apollodata.com/tools/graphql-subscriptions/authentication.html)**.
+If the return value of `onConnect` function is an object then its elements will be added to the `context` which will be used by all resolvers. We are generating this context by using our existing `buildOptions` function and we are passing a dummy http request object with `authorization` header because `buildOptions` function expects http request object as first argument. For production-ready apps you can pass authorization token from client side and detect current user as mentioned in this **[guide](http://dev.apollodata.com/tools/graphql-subscriptions/authentication.html)**.
 
 </Instruction>
 


### PR DESCRIPTION
# Issue
When I execute this subscription

```js
subscription{
  Link(
  	filter: {
    	mutation_in: [CREATED]
  	}
  )
  {
    mutation
    node{
      url
      description
      postedBy{
        name
      }
    }
  }
}
```

I am getting the error mentioned in [this stack-overflow question](https://stackoverflow.com/questions/45769302/custom-field-not-getting-published-in-subscription-apollo-server). 

<p><details>
 <summary><b>Error Screenshot</b></summary>
<img src="https://user-images.githubusercontent.com/8843216/31104144-e8bad28c-a7f8-11e7-924e-d67e714005b2.png"/>
</details></p>

- - -
So I added the relevant code to fix this issue and some text explaining what we are doing as shown below

```js
server.listen(PORT, () => {
  SubscriptionServer.create(
    {
      execute,
      subscribe,
      schema,
      onConnect() {
        const dummyReq = {
          headers: {
            authorization: 'bearer token-foo@bar.com',
          },
        };
        return buildOptions(dummyReq).then(({ context }) => {
          return context; // This context object is passed to all resolvers.
        });
    },
    {server, path: '/subscriptions'},
  );
  console.log(`Hackernews GraphQL server running on port ${PORT}.`)
});
```

> If the return value of `onConnect` function is an object then its elements will be added to the `context` which will be used by all resolvers. We are generating this context by using our existing `buildOptions` function and we are passing a dummy http request object with `authorization` header because `buildOptions` function expects http request object as first argument. For production-ready apps you can pass authorization token from client side and detect current user as mentioned in this **[guide](http://dev.apollodata.com/tools/graphql-subscriptions/authentication.html)**.

- - -
