### PR TITLE
Fix typo: detailled -> detailed

### DIFF
--- a/content/frontend/react-relay/3-mutations-creating-links.md
+++ b/content/frontend/react-relay/3-mutations-creating-links.md
@@ -3,7 +3,7 @@ title: "Mutations: Creating Links"
 pageTitle: "GraphQL Mutations with React & Relay Tutorial"
 description: "Learn how to use Relay Modern's new Mutation API to send mutations to a GraphQL server. With Relay Modern you can also update the cache directly after the mutation."
 question: What's one of the major changes of Relay Modern compared to Relay Classic?
-answers: ["Detailled documentation and many code samples", "An imperative and more predictible mutation API", "Declaring data dependencies as fragments alongisde React components", "Relay Modern also includes a new server component"]
+answers: ["Detailed documentation and many code samples", "An imperative and more predictible mutation API", "Declaring data dependencies as fragments alongisde React components", "Relay Modern also includes a new server component"]
 correctAnswer: 1
 videoId: eIsctkVmq4Y
 duration: 10

--- a/src/components/home/WhatWeBuild.tsx
+++ b/src/components/home/WhatWeBuild.tsx
@@ -81,7 +81,7 @@ export default function WhatWeBuild() {
             </div>
             <div className="point">
               <Checkmark />
-              <p>Detailled instructions &amp; explanations</p>
+              <p>Detailed instructions &amp; explanations</p>
             </div>
             <div className="point">
               <Checkmark />


### PR DESCRIPTION
<img width="589" alt="screen shot 2017-10-06 at 1 16 02 pm" src="https://user-images.githubusercontent.com/90494/31297041-59d247c8-aa99-11e7-9aea-00cbc1130775.png">
