### PR TITLE
Update graphql version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "resolutions": {
-    "graphql": "0.10.3"
+    "graphql": "0.11.7"
   },
   "dependencies": {
     "algoliasearch": "^3.24.0",
@@ -22,7 +22,7 @@
     "gatsby-transformer-remark": "next",
     "graphcool-graphiql": "^1.8.13",
     "graphcool-styles": "^0.1.31",
-    "graphql": "^0.10.3",
+    "graphql": "^0.11.7",
     "graphql-request": "^1.2.0",
     "lodash": "^4.17.4",
     "node-fetch": "^1.7.1",


### PR DESCRIPTION
A clean clone result in such errors:
- In browser:
![screen shot 2017-10-19 at 1 35 51 pm](https://user-images.githubusercontent.com/10948652/31795055-43fad010-b4d9-11e7-8412-fefb776ccbb3.png)
- In console: `There was an error while compiling your site's GraphQL queries
Error: Schema must be an instance of GraphQLSchema. Also ensure that there are not multiple versions of GraphQL installed in your node_modules directory.`

After some research, I found that it could be caused by multiple versions of graphql, then I ran `npm ls graphql`:
![screen shot 2017-10-19 at 2 07 52 pm](https://user-images.githubusercontent.com/10948652/31795093-63cd2afa-b4d9-11e7-8648-d1e729de323f.png)

After updating graphql to 0.11.7, I was able to ran the app and preview the site locally. Not sure if updating graphql version will cause any other issues.

Please review.