### PR TITLE
Fix typo in the Java code on 3-Mutations

### DIFF
--- a/content/backend/graphql-java/3-mutations.md
+++ b/content/backend/graphql-java/3-mutations.md
@@ -69,7 +69,7 @@ Finally, register this new resolver the same way you registered `Query` inside `
 
 ```java(path=".../hackernews-graphql-java/src/main/java/com/howtographql/hackernews/GraphQLEndpoint.java")
 private static GraphQLSchema buildSchema(LinkRepository linkRepository) {
-    return SchemaParser.*newParser*()
+    return SchemaParser.newParser()
         .file("schema.graphqls")
         .resolvers(new Query(linkRepository), new Mutation(linkRepository))
         .build()


### PR DESCRIPTION
Fixed a typo in the Java code removing '*' delimiter of newParser() method.