### PR TITLE
Fix sandbox in basics/2-core-concepts

### DIFF
--- a/src/components/Tutorials/Playground.tsx
+++ b/src/components/Tutorials/Playground.tsx
@@ -411,12 +411,14 @@ class Playground extends React.Component<Props & PlaygroundState, State> {
   }
 }
 
-const schema = `type Post {
+const schema = `type Post @model {
+  id: ID! @isUnique
   title: String!
   author: Person! @relation(name: "UserPosts")
 }
 
-type Person {
+type Person @model {
+  id: ID! @isUnique
   name: String!
   age: Int!
   posts: [Post!]! @relation(name: "UserPosts")


### PR DESCRIPTION
It seems that about a month ago sandboxes in this chapter stopped working because schema became invalid (according to #243). And several days ago because of graphcool/graphcool#817 it started to require `@model` on all types.
So, the current schema:
```
type Post {
  title: String!
  author: Person! @relation(name: "UserPosts")
}

type Person {
  name: String!
  age: Int!
  posts: [Post!]! @relation(name: "UserPosts")
}
```

started to produce errors
> The schema is invalid:   The model `Post` is missing the @model directive. Please add it. See: https://github.com/graphcool/graphcool/issues/817  The model `Person` is missing the @model directive. Please add it. See: https://github.com/graphcool/graphcool/issues/817  All models must specify the `id` field: `id: ID! @isUnique`  All models must specify the `id` field: `id: ID! @isUnique`

I added both `@model` and `id: ID! @isUnique` for both `Post` and `Person` and managed to get sandboxes working.

However, due to the fact that I've just started to learn GraphQL, I cannot say if text in [corresponding file](/howtographql/howtographql/blob/master/content/graphql/basics/2-core-concepts.md) should be updated as well to reflect this changes.

Closes #243.