### PR TITLE
Fix scrollbars bug on swipeable categories on index page in Chrome

### DIFF
--- a/src/components/home/Chooser.tsx
+++ b/src/components/home/Chooser.tsx
@@ -302,6 +302,9 @@ export default class Chooser extends React.Component<Props, State> {
               overflow: 'visible',
               width: 90,
             }}
+            slideStyle={{
+              overflow: 'hidden'
+            }}
             index={selectedCategoryIndex}
             onChangeIndex={this.handleChangeSelectedCategoryIndex}
           >


### PR DESCRIPTION
These guys in latest Chrome:
![](https://i.imgur.com/ewCLlyh.png)

Closes #224.