### PR TITLE
[ruby] Remove dummy mutation

### DIFF
--- a/content/backend/graphql-ruby/2-queries.md
+++ b/content/backend/graphql-ruby/2-queries.md
@@ -92,24 +92,6 @@ end
 
 </Instruction>
 
-<Instruction>
-
-Also update the content in:
-
-```ruby(path=".../graphql-ruby/app/graphql/types/mutation_type.rb")
-Types::MutationType = GraphQL::ObjectType.define do
-  name "Mutation"
-
-  # queries are just represented as fields
-  field :allLinks, !types[Types::LinkType] do
-    # resolve would be called in order to fetch data for that field
-    resolve -> (obj, args, ctx) { Link.all }
-  end
-end
-```
-
-</Instruction>
-
 Resolvers can be either of two things:
 
 * object responding to call method accepting 3 arguments - obj, arg, ctx (like `lambda` or `Proc` objects)


### PR DESCRIPTION
As a newbie to GraphQL this part of the tutorial confuses me: why would I declare a mutation that has a "getter" name (`allLinks`) and does not mutate anything?

From the history of the tuto I figured that the graphql-ruby `install` generator used to create an empty Mutation type and this code was just a filler to prevent an error. It's not the case anymore though: a dummy "testMutation" is created by default by the generator.

So I think it's less confusing to remove this part from the tutorial.