### PR TITLE
Fix blocking regression: 5-7 chapters in React+Apollo are inaccessible

### DIFF
--- a/content/frontend/react-apollo/5-authentication.md
+++ b/content/frontend/react-apollo/5-authentication.md
@@ -5,7 +5,6 @@ description: "Learn best practices to implement authentication with GraphQL & Ap
 question: "What are the names of the two mutations that are added to the Graphcool project after the Email+Password Auth Provider was enabled?"
 answers: ["loginUser & logoutUser", "signinUser & createUser", "createUser & loginUser", "signinUser & logoutUser"]
 correctAnswer: 1
-videoAuthor: "Abhi Aiyer"
 videoId: MiNDIWK7Q1I
 duration: 12
 videoAuthor: "Abhi Aiyer"

--- a/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
+++ b/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
@@ -5,7 +5,6 @@ description: "Learn how to use Apollo's imperative store API to update the cache
 question: "What does the 'graphcool push' command do?"
 answers: ["It uploads the local schema changes to the remote Graphcool project", "It pushes a git repository to Graphcool so you can manage your project and code together", "It tells the server to push its remote schema changes into the local project file", "There is no 'graphcool push' command"]
 correctAnswer: 0
-videoAuthor: "Abhi Aiyer"
 videoId: o0w0HS5vG5s
 duration: 8
 videoAuthor: "Abhi Aiyer"

--- a/content/frontend/react-apollo/7-filtering-searching-the-list-of-links.md
+++ b/content/frontend/react-apollo/7-filtering-searching-the-list-of-links.md
@@ -5,7 +5,6 @@ description: "Learn how to use filters with GraphQL and Apollo Client. Graphcool
 question: "What's the purpose of the 'withApollo' function?"
 answers: ["You use it to send queries and mutations to a GraphQL server", "When wrapped around a component, it injects the 'ApolloClient' instance into the component's props", "You have to use it everywhere where you want to use Apollo functionality", "It parses GraphQL code"]
 correctAnswer: 1
-videoAuthor: "Abhi Aiyer"
 videoId: sycCQujmWzg
 duration: 3
 videoAuthor: "Abhi Aiyer"


### PR DESCRIPTION
Commit 957a85753f46b0bbbc80fc164052ccfe01d59178 introduced a regression which caused three chapters of React+Apollo path (5th, 6th and 7th) to become inaccessible from any chapters list due to a duplicate `videoAuthor` fields and made 4th chapter to point to 8th chapter.

![](https://i.imgur.com/EY2OUje.png)

![](https://i.imgur.com/fM9Om8w.png)

![image](https://user-images.githubusercontent.com/5000549/32192944-ec94b60a-bddf-11e7-802f-1b6467de8cfc.png)