### PR TITLE
Allow chapters without quizzes to be considered in results

### DIFF
--- a/src/actions/quiz.ts
+++ b/src/actions/quiz.ts
@@ -7,6 +7,10 @@ export const answerCorrectly = (path: string): Action => ({
   path,
   type: 'answer correctly',
 })
+export const markAsWatched = (path: string): Action => ({
+  path,
+  type: 'mark as watched',
+})
 export const addAnswer = (path: string, answer: number): Action => ({
   path,
   payload: answer,

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -11,6 +11,7 @@ import { defaultReaction, QuizState } from '../../reducers/quiz'
 import {
   addAnswer,
   answerCorrectly,
+  markAsWatched,
   setRememberSkipped,
   skip,
 } from '../../actions/quiz'
@@ -27,9 +28,18 @@ interface Props {
   skip: (path: string) => void
   addAnswer: (path: string, answer: number) => void
   answerCorrectly: (path: string) => void
+  markAsWatched: (path: string) => void
 }
 
 class Quiz extends React.Component<Props & QuizState, {}> {
+  componentDidMount() {
+    this.markAsWatchedIfNoQuestion()
+  }
+
+  componentDidUpdate() {
+    this.markAsWatchedIfNoQuestion()
+  }
+
   render() {
     const {
       question,
@@ -192,6 +202,16 @@ class Quiz extends React.Component<Props & QuizState, {}> {
     )
   }
 
+  private markAsWatchedIfNoQuestion = () => {
+    const { question, quizReactions, markAsWatched, path } = this.props
+    const hasQuestion = Boolean(question)
+    const reaction = quizReactions[path]
+
+    if (!hasQuestion && !Boolean(reaction && reaction.watched)) {
+        markAsWatched(path)
+    }
+  }
+
   private toggleRememberSkip = () => {
     this.props.setRememberSkipped(!this.props.rememberSkipped)
   }
@@ -287,6 +307,7 @@ function Answer({ text, onClick, checked, correct }: AnswerProps) {
 export default connect(state => state.quiz, {
   addAnswer,
   answerCorrectly,
+  markAsWatched,
   setRememberSkipped,
   skip,
 })(Quiz)

--- a/src/components/Steps/DottedListItem.tsx
+++ b/src/components/Steps/DottedListItem.tsx
@@ -30,8 +30,9 @@ const DottedListItem = ({
   last,
   skipped,
   answeredCorrectly,
+  watched,
 }: Props & QuizReaction) => {
-  const done = skipped || answeredCorrectly
+  const done = skipped || answeredCorrectly || watched
   return (
     <div
       className={cn('dotted-list-item', {

--- a/src/components/Success/Result.tsx
+++ b/src/components/Success/Result.tsx
@@ -33,7 +33,7 @@ function Result({ steps, ...state }: Props & QuizState) {
     })
     .filter(
       (reaction: QuizReaction) =>
-        reaction.answerIndeces && reaction.answerIndeces.length > 0,
+        reaction.answerIndeces && reaction.answerIndeces.length > 0 || reaction.watched,
     )
 
   const groupedReactions = groupBy(filteredReactions, reaction =>
@@ -47,6 +47,9 @@ function Result({ steps, ...state }: Props & QuizState) {
       const scores = groupSteps.map(step => {
         const reaction = state.quizReactions[step.link]
         if (reaction) {
+          if (reaction.watched) {
+            return { score: 4, path: step.link }
+          }
           const score = reaction.answeredCorrectly && reaction.answerIndeces
             ? 5 - reaction.answerIndeces.length
             : 0

--- a/src/reducers/quiz.ts
+++ b/src/reducers/quiz.ts
@@ -7,6 +7,7 @@ export interface QuizReaction {
   answerIndeces?: number[]
   skipped?: boolean
   answeredCorrectly?: boolean
+  watched?: boolean
 }
 
 export const defaultQuizState: QuizState = {
@@ -24,6 +25,7 @@ export const defaultReaction: QuizReaction = {
   answerIndeces: [],
   answeredCorrectly: false,
   skipped: false,
+  watched: false,
 }
 
 export default function quizReducer(
@@ -39,6 +41,9 @@ export default function quizReducer(
 
     case 'answer correctly':
       return updateReaction(state, action.path, { answeredCorrectly: true })
+
+    case 'mark as watched':
+      return updateReaction(state, action.path, { watched: true })
 
     case 'add answer':
       const currentReaction = action.path


### PR DESCRIPTION
To date, it's impossible to have 100% in results if a path has a chapter without quiz. Usually it's the last "Summary" chapter.
![image](https://user-images.githubusercontent.com/5000549/32373340-0256c39e-c0c3-11e7-8280-6f19d0e93394.png)
So this PR is to make it possible for that kind of chapters to be considered in results if they were watched.