### PR TITLE
Fix changed line hightlight in /react-apollo/9-pagination

### DIFF
--- a/content/frontend/react-apollo/9-pagination.md
+++ b/content/frontend/react-apollo/9-pagination.md
@@ -21,7 +21,7 @@ Once more, you first need to prepare the React components for this new functiona
 
 Open `App.js` and adjust the render method like so:
 
-```js{4,8,9}(path=".../hackernews-react-apollo/src/components/App.js")
+```js{7,11,12}(path=".../hackernews-react-apollo/src/components/App.js")
 render() {
     return (
       <div className='center w85'>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5000549/32373641-785b8d8a-c0c4-11e7-9f63-81658fac95d7.png)

After (as it should be):
![image](https://user-images.githubusercontent.com/5000549/32373656-870e4412-c0c4-11e7-9738-1e1b4df458e2.png)
