### PR TITLE
Remove broken obsolete link on /

### DIFF
--- a/src/components/home/Chooser.tsx
+++ b/src/components/home/Chooser.tsx
@@ -291,12 +291,6 @@ export default class Chooser extends React.Component<Props, State> {
                     Choose your favorite technology
                   </span>
                 </Link>
-                <Duration
-                  duration={2}
-                  total={false}
-                  dark={true}
-                  link={`/tutorials/choose`}
-                />
               </div>
             </DottedListItem>
           </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5000549/32438738-ce3d9e0c-c315-11e7-86fa-5bc783f4d2d4.png)

There's no video in that section and the link points to a non-existent path. This PR fixes that.