### PR TITLE
Fix definition for AuthenticateUserMutation

### DIFF
--- a/content/frontend/react-apollo/5-authentication.md
+++ b/content/frontend/react-apollo/5-authentication.md
@@ -499,14 +499,12 @@ const SIGNUP_USER_MUTATION = gql`
 
 const AUTHENTICATE_USER_MUTATION = gql`
   mutation AuthenticateUserMutation($email: String!, $password: String!) {
-    authenticateUser(email: {
+    authenticateUser(
       email: $email,
       password: $password
-    }) {
+    ) {
+      id
       token
-      user {
-        id
-      }
     }
   }
 `


### PR DESCRIPTION
The mutation as written in the current tutorial does not work when you log out and try to log in with your created user, since the definition of `AuthenticateUserPayload` in `authenticate.graphql` does not match. This version matches the definition and ensures that the user can log in successfully.