### PR TITLE
[FIX](ApolloClient)[!PR]

### DIFF
--- a/content/frontend/vue-apollo/2-queries-loading-links.md
+++ b/content/frontend/vue-apollo/2-queries-loading-links.md
@@ -166,23 +166,28 @@ You need to make one more change before testing out the app.
 Open `src/main.js` and remove the two references to router for now. After removing them, `src/main.js` should look like this:
 
 ```js(path=".../hackernews-vue-apollo/src/main.js")
-import { ApolloClient, createBatchingNetworkInterface } from 'apollo-client'
 import 'tachyons'
 import Vue from 'vue'
 import VueApollo from 'vue-apollo'
+import { ApolloClient } from 'apollo-client'
+import { HttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory'
 
 import App from './App'
 
 Vue.config.productionTip = false
 
-const networkInterface = createBatchingNetworkInterface({
-  uri: '__SIMPLE_API_ENDPOINT__'
-})
-
 const apolloClient = new ApolloClient({
-  networkInterface,
-  connectToDevTools: true
-})
+    link: new HttpLink({
+        uri: '__SIMPLE_API_ENDPOINT',
+    }),
+    cache: new InMemoryCache(),
+    connectToDevTools: true,
+});
+
+const apolloProvider = new VueApollo({
+    defaultClient: apolloClient,
+});
 
 Vue.use(VueApollo)
 

--- a/content/frontend/vue-apollo/2-queries-loading-links.md
+++ b/content/frontend/vue-apollo/2-queries-loading-links.md
@@ -179,7 +179,7 @@ Vue.config.productionTip = false
 
 const apolloClient = new ApolloClient({
     link: new HttpLink({
-        uri: '__SIMPLE_API_ENDPOINT',
+        uri: '__SIMPLE_API_ENDPOINT__',
     }),
     cache: new InMemoryCache(),
     connectToDevTools: true,


### PR DESCRIPTION
As Apollo is evolving, the ApolloClient require to receive a HttpLink instance followed by a InMemoryCache instance, this correction only applies to Apollo 2.0.