### PR TITLE
Fix broken graphql-js/0-introduction and ember-apollo/8-summary chapters

### DIFF
--- a/content/backend/graphql-js/0-introduction.md
+++ b/content/backend/graphql-js/0-introduction.md
@@ -5,7 +5,6 @@ description: "Learn how to build a GraphQL server with graphql-js, Node.JS, Expr
 question: Which of these is a requirement for GraphQl servers?
 answers: ["Run in NodeJS", "Real time subscriptions support", "Validate incoming GraphQL requests", "Automatically generate queries and mutations from schema types"]
 correctAnswer: 2
-description: Read about what you'll learn in the graphql.js tutorial
 ---
 
 ### Motivation

--- a/content/frontend/ember-apollo/8-summary.md
+++ b/content/frontend/ember-apollo/8-summary.md
@@ -1,6 +1,6 @@
 ---
 title: Summary
-pageTitle: "Fullstack GraphQL, Ember & Apollo Tutorial with ember-apollo-client“
+pageTitle: "Fullstack GraphQL, Ember & Apollo Tutorial with ember-apollo-client"
 description: "In this Fullstack GraphQL Tutorial with Ember & Apollo Client you learned how to build a production-ready Hackernews clone using ember-apollo-client & Graphcool."
 ---
 


### PR DESCRIPTION
To date these two chapters are broken and not shown in steps lists.

This PR fixes that.