### PR TITLE
Vote and Link updateQuery subscriptionData missing .data

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -169,7 +169,7 @@ Still in `LinkList.js` implement `updateQuery` like so:
 ```js(path=".../hackernews-react-apollo/src/components/LinkList.js")
 updateQuery: (previous, { subscriptionData }) => {
   const newAllLinks = [
-    subscriptionData.Link.node,
+    subscriptionData.data.Link.node,
     ...previous.allLinks
   ]
   const result = {
@@ -244,8 +244,8 @@ _subscribeToNewVotes = () => {
       }
     `,
     updateQuery: (previous, { subscriptionData }) => {
-      const votedLinkIndex = previous.allLinks.findIndex(link => link.id === subscriptionData.Vote.node.link.id)
-      const link = subscriptionData.Vote.node.link
+      const votedLinkIndex = previous.allLinks.findIndex(link => link.id === subscriptionData.data.Vote.node.link.id)
+      const link = subscriptionData.data.Vote.node.link
       const newAllLinks = previous.allLinks.slice()
       newAllLinks[votedLinkIndex] = link
       const result = {


### PR DESCRIPTION
The Realtime Updates with GraphQL Subscriptions tutorial step is currently returning an error "TypeError: Cannot read property 'node' of undefined " . 
This is because the Vote and Link updateQuery  subscriptionData has a data attribute, but the Link.node and Vote.node are both currently trying to be accessed on subscriptionData directly