### PR TITLE
fix: 404 error when enabling graphiql in graphql.js: 2-queries

### DIFF
--- a/content/backend/graphql-js/2-queries.md
+++ b/content/backend/graphql-js/2-queries.md
@@ -92,8 +92,12 @@ const {graphqlExpress, graphiqlExpress} = require('apollo-server-express');
 
 // ...
 
-app.use('/graphiql', graphiqlExpress({
-  endpointURL: '/graphql',
+// bodyParser is needed just for POST.
+app.use('/graphql', bodyParser.json(), graphqlExpress({ 
+  schema: schema }));
+
+// if you want GraphiQL enabled
+app.get('/graphiql', graphiqlExpress({ endpointURL: '/graphql' })); 
 }));
 ```
 


### PR DESCRIPTION
When attempting to run the application as shown at the end of 02-queries lesson, the graphiql tool opens correctly, but I am unable to connect to the graphql server with a `404 error "Cannot POST /graphql"`.  

Instantiating `graphiqlExpress` within the `app.get` function and `graphqlExpress` within the `app.use` function as is shown in apollo's docs fixed the issue for me.  

[Reference to apollo-server-express docs](https://github.com/apollographql/apollo-server#express)