### PR TITLE
Clarify 9-subscriptions instructions

### DIFF
--- a/content/backend/graphql-js/9-subscriptions.md
+++ b/content/backend/graphql-js/9-subscriptions.md
@@ -149,7 +149,6 @@ const {SubscriptionServer} = require('subscriptions-transport-ws');
 After that, replace the call to `app.listen` in this same file with this:
 
 ```js(path=".../hackernews-graphql-js/src/index.js")
-const PORT = 3000;
 const server = createServer(app);
 server.listen(PORT, () => {
   SubscriptionServer.create(
@@ -164,9 +163,10 @@ server.listen(PORT, () => {
 
 <Instruction>
 
-To finish up, tell `graphiqlExpress` that the subscriptions endpoint is different from the regular GraphQL one:
+To finish up, tell `graphiqlExpress` that the subscriptions endpoint is different from the regular GraphQL one. Make sure to move the `PORT` initialization above `app.use` so it can be used in `subscriptionsEndpoint`:
 
 ```js{4-4}(path=".../hackernews-graphql-js/src/index.js")
+const PORT = 3000;
 app.use('/graphiql', graphiqlExpress({
   endpointURL: '/graphql',
   passHeader: `'Authorization': 'bearer token-foo@bar.com'`,


### PR DESCRIPTION
I was going through Lesson 9-Subscriptions and found what I think might be a set of slightly confusing instructions in the 'Configuring the `SubscriptionServer`' section.

After the express server is replaced by a http server, we are instructed to tell `graphiqlExpress` the subscriptions endpoint is different from the regular GraphQL. At this point it should also be mentioned that the `const PORT=3000;` declaration should be placed above `app.use` as shown below.

```js
const PORT = 3000;
app.use('/graphiql', graphiqlExpress({
  endpointURL: '/graphql',
  passHeader: `'Authorization': 'bearer token-foo@bar.com'`,
  subscriptionsEndpoint: `ws://localhost:${PORT}/subscriptions`,
}));
```

The code snippet currently preceding this one is a bit misleading as it shows `const PORT=3000;` right above `const server = createServer(app);`. Having the declaration placed there causes the server to hang on attempted connections.