### PR TITLE
mongodb version breaks tutorial

### DIFF
--- a/content/backend/graphql-js/4-connectors.md
+++ b/content/backend/graphql-js/4-connectors.md
@@ -25,6 +25,7 @@ First you'll need to get MongoDB up and running.
 <Instruction>
 
 **Step 2**: Install MongoDB's driver for NodeJS, via the command `npm i --save mongodb@2.2.33`. 
+
 **NOTE:** The current version of mongodb (3.x) had some API changes that will break the tutorial. Make sure you use the 2.x version.
 
 </Instruction>

--- a/content/backend/graphql-js/4-connectors.md
+++ b/content/backend/graphql-js/4-connectors.md
@@ -24,7 +24,8 @@ First you'll need to get MongoDB up and running.
 
 <Instruction>
 
-**Step 2**: Install MongoDB's driver for NodeJS, via the command `npm i --save mongodb@2.2.33`. ***NOTE:*** The current version of mongodb (3.x) had some API changes that will break the tutorial. Make sure you use the 2.x version.
+**Step 2**: Install MongoDB's driver for NodeJS, via the command `npm i --save mongodb@2.2.33`. 
+**NOTE:** The current version of mongodb (3.x) had some API changes that will break the tutorial. Make sure you use the 2.x version.
 
 </Instruction>
 

--- a/content/backend/graphql-js/4-connectors.md
+++ b/content/backend/graphql-js/4-connectors.md
@@ -24,7 +24,7 @@ First you'll need to get MongoDB up and running.
 
 <Instruction>
 
-**Step 2**: Install MongoDB's driver for NodeJS, via the command `npm i --save mongodb`.
+**Step 2**: Install MongoDB's driver for NodeJS, via the command `npm i --save mongodb@2.2.33`. ***NOTE:*** The current version of mongodb (3.x) had some API changes that will break the tutorial. Make sure you use the 2.x version.
 
 </Instruction>
 


### PR DESCRIPTION
If you do a npm install  --save mongodb the version pulled will be 3.x which leads to breaking db.collection (function undefined).

This change just denotes the version explicitly to 2.x, but the tutorial should probably be updated at some point once the 3.x API is released.