### PR TITLE
typofix in 3. mutations-creating-links.md

### DIFF
--- a/content/frontend/react-apollo/3-mutations-creating-links.md
+++ b/content/frontend/react-apollo/3-mutations-creating-links.md
@@ -12,7 +12,7 @@ correctAnswer: 2
 
 In this section, you'll learn how you can send mutations with Apollo. It's actually not that different from sending queries and follows the same three steps that were mentioned before, with a minor (but logical) difference in step 3:
 
-1. write the mutation as a JSava riptconstant using the `gql` parser function
+1. write the mutation as a Javascript constant using the `gql` parser function
 2. use the `graphql` container to wrap your component with the mutation
 3. use the mutation function that gets injected into the component's props
 


### PR DESCRIPTION
#typofix
Changed 'write the mutation as a JSava riptconstant using the gql parser function'
to 'write the mutation as a Javascript constant using the gql parser function'.