### PR TITLE
Update 5-authentication.md

### DIFF
--- a/content/frontend/react-apollo/5-authentication.md
+++ b/content/frontend/react-apollo/5-authentication.md
@@ -503,10 +503,8 @@ const AUTHENTICATE_USER_MUTATION = gql`
       email: $email,
       password: $password
     ) {
+      id
       token
-      user {
-        id
-      }
     }
   }
 `


### PR DESCRIPTION
The authenticateUser mutation returns an AuthenticateUserPayload, having two fields : id & token.
So querying the id of the user who is trying to sign in results in an error :
> Uncaught (in promise) Error: GraphQL error: Cannot query field 'user' on type 'AuthenticateUserPayload'. (line 4, column 5): ...