### PR TITLE
Fix MongoDB connection code

### DIFF
--- a/content/backend/graphql-js/4-connectors.md
+++ b/content/backend/graphql-js/4-connectors.md
@@ -40,11 +40,14 @@ Create a file at `src/mongo-connector.js` like this:
 const {MongoClient} = require('mongodb');
 
 // 1
-const MONGO_URL = 'mongodb://localhost:27017/hackernews';
+const MONGO_URL = 'mongodb://localhost:27017/';
+const MONGO_DATABASE = 'hackernews';
 
 // 2
 module.exports = async () => {
-  const db = await MongoClient.connect(MONGO_URL);
+  const client = await MongoClient.connect(MONGO_URL);
+  const db = client.db(MONGO_DATABASE);
+  
   return {Links: db.collection('links')};
 }
 ```

--- a/content/backend/graphql-js/5-authentication.md
+++ b/content/backend/graphql-js/5-authentication.md
@@ -53,7 +53,9 @@ input AUTH_PROVIDER_EMAIL {
 
 ```js{5-5}(path=".../hackernews-graphql-js/src/mongo-connector.js")
 module.exports = async () => {
-    const db = await MongoClient.connect(MONGO_URL);
+    const client = await MongoClient.connect(MONGO_URL);
+    const db = client.db(MONGO_DATABASE);
+    
     return {
         Links: db.collection('links'),
         Users: db.collection('users'),


### PR DESCRIPTION
Pre existing code was not working, since `MongoClient.connect()` returns a Promise resolving to a MongoClient object which does not have a `collection()` method. This method is available on the Db object, that is returned from the `mongoClient.db()` call.