### PR TITLE
Update 4-connectors.md

### DIFF
--- a/content/backend/graphql-js/4-connectors.md
+++ b/content/backend/graphql-js/4-connectors.md
@@ -48,6 +48,23 @@ module.exports = async () => {
   return {Links: db.collection('links')};
 }
 ```
+edit: as of npm mongodb >= v3.0, the connector should look like this:
+```
+const { MongoClient } = require('mongodb')
+
+// 1
+const MONGO_URL = 'mongodb://localhost:27017/hackernews'
+// 2
+module.exports = async () => {
+  try {
+    const client = await MongoClient.connect(MONGO_URL)
+    const db = client.db('hackernews')
+    return { Links: db.collection('links') }
+  } catch (e) {
+    console.log(e)
+  }
+}
+```
 
 </Instruction>
 


### PR DESCRIPTION
the syntax for connecting to mongodb (>v.3) has slightly changed.
MongoClient.connect is returning the parent object (client) instead of (db)
const client = await MongoClient.connect(MONGO_URL)
const db = client.db('hackernews')