### PR TITLE
Update Subscription page to include `withFilter`

### DIFF
--- a/content/backend/graphql-js/9-subscriptions.md
+++ b/content/backend/graphql-js/9-subscriptions.md
@@ -76,6 +76,7 @@ module.exports = new PubSub();
 Make sure to include it at the top of your resolvers' file:
 
 ```js(path=".../hackernews-graphql-js/src/schema/resolvers.js")
+const {withFilter} = require('graphql-subscriptions');
 const pubsub = require('../pubsub');
 ```
 
@@ -88,7 +89,9 @@ You can now add the resolver for this subscription, like this:
 ```js(path=".../hackernews-graphql-js/src/schema/resolvers.js")
 Subscription: {
   Link: {
-    subscribe: () => pubsub.asyncIterator('Link'),
+    subscribe: withFilter(() => pubsub.asyncIterator('Link'), (payload, variables) => {
+        return variables.filter.mutation_in.indexOf(payload.Link.mutation) >= 0;
+    }),
   },
 },
 ```


### PR DESCRIPTION
Currently, by following the tutorial the subscriber will get events for `_ModelMutationType` that he\she didn't subscribe to.

for example, subscribing with the following Subscription query:
```graphql
subscription {
  Link(filter: {
    mutation_in: [UPDATED]
  }) {
    mutation
    node {
      url
      description
    }
  }
}
```

The user will still get data like this:
```graphql
{
  "Link": {
    "mutation": "CREATED",
    "node": {
      "url": "http://www.google.com",
      "description": "sub test"
    }
  }
}
```

The proposed changes will prevent events the user didn't subscribe to from reaching him\her.

I believe a small description should be added to explain to the user what's the purpose of the `withFilter` function and the function that we pass as the 2nd variable.
An explanation from the `graphql-subscriptions` docs can be found [here](https://github.com/apollographql/graphql-subscriptions#filters)