### PR TITLE
Add the configuration of the context for the SubscriptionServer

### DIFF
--- a/content/backend/graphql-js/9-subscriptions.md
+++ b/content/backend/graphql-js/9-subscriptions.md
@@ -149,11 +149,19 @@ const {SubscriptionServer} = require('subscriptions-transport-ws');
 After that, replace the call to `app.listen` in this same file with this:
 
 ```js(path=".../hackernews-graphql-js/src/index.js")
+const subscriptionBuildOptions = async (connectionParams,webSocket) =>
+{
+  return {
+    dataloaders: buildDataloaders(mongo),
+    mongo
+  }
+}
+
 const PORT = 3000;
 const server = createServer(app);
 server.listen(PORT, () => {
   SubscriptionServer.create(
-    {execute, subscribe, schema},
+    {execute, subscribe, schema, onConnect: subscriptionBuildOptions},
     {server, path: '/subscriptions'},
   );
   console.log(`Hackernews GraphQL server running on port ${PORT}.`)


### PR DESCRIPTION
Thanks to the answer of Marii on stack overflow (https://stackoverflow.com/a/47625284), I was able to fix my issue with subscription.
On the tutorial, it was missing the configuration of the context on the SubscriptionServer.

With this modification it is possible to watch modification of links with the possibility to get client information.
Before the modification, the following request creates an error because of unknown context value.

subscription {
  Link(filter: {mutation_in: [CREATED]}) {
    node {
      url,
      postedBy {name}	
    }
  }
}