### PR TITLE
Fix : html code rendering

### DIFF
--- a/content/frontend/angular-apollo/2-queries-loading-links.md
+++ b/content/frontend/angular-apollo/2-queries-loading-links.md
@@ -52,11 +52,11 @@ export class LinkItemComponent implements OnInit {
 </Instruction>
 
 <Instruction>
+
 ```html(path=".../hackernews-angular-apollo/src/app/link-item/link-item.component.html")
-
 <div>{{link.description}} ({{link.url}})</div>
-
 ```
+
 </Instruction>
 
 Note, we will be writing all our typings in a `./src/app/types.ts` file and merely importing these types into components as needed.
@@ -116,12 +116,12 @@ export class LinkListComponent implements OnInit {
 </Instruction>
 
 <Instruction>
+
 Then, add the following code in `link-list.component.html`:
 
 ```html(path=".../hackernews-angular-apollo/src/app/link-list/link-list.component.html")
 
-<hn-link-item *ngFor="let link of linksToRender"
-          [link]="link">
+<hn-link-item *ngFor="let link of linksToRender" [link]="link">
 </hn-link-item>
 
 ```
@@ -165,6 +165,7 @@ export class AppModule {
 ```
 </Instruction>
 <Instruction>
+
 Then, open `app.component.html` and replace the current contents with the following:
 
 ```html(path=".../hackernews-angular-apollo/src/app/app.component.html")
@@ -266,8 +267,7 @@ Open up `src/app/link-list/link-list.component.html`, update the HTML template t
 ```html(path=".../hackernews-angular-apollo/src/app/link-list/link-list.component.html")
 
 <h4 *ngIf="loading">Loading...</h4>
-<hn-link-item *ngFor="let link of allLinks"
-          [link]="link">
+<hn-link-item *ngFor="let link of allLinks" [link]="link">
 </hn-link-item>
 
 
@@ -275,6 +275,7 @@ Open up `src/app/link-list/link-list.component.html`, update the HTML template t
 </Instruction>
 
 <Instruction>
+
 Then, open up `src/app/link-list/link-list.component.ts`, import `ALL_LINKS_QUERY`, remove the hard-coded `linksToRender`, and inject the `Apollo` service. Your `LinkListComponent` component should now look like this:
 
 ```ts{5-6,17-18,23-25,27-28}(path=".../hackernews-angular-apollo/src/app/link-list/link-list.component.ts")


### PR DESCRIPTION
HTML code for the `link-item.component.html` wasn't rendering as expected because of a missing newline.