### PR TITLE
Fix authToken for subscriptions and change logout route in early stages of the tutorial

### DIFF
--- a/content/frontend/react-apollo/5-authentication.md
+++ b/content/frontend/react-apollo/5-authentication.md
@@ -171,7 +171,7 @@ render() {
         {authToken ?
           <div className='ml1 pointer black' onClick={() => {
             localStorage.removeItem(AUTH_TOKEN)
-            this.props.history.push(`/new/1`)
+            this.props.history.push(`/`)
           }}>logout</div>
           :
           <Link to='/login' className='ml1 no-underline black'>login</Link>

--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -58,7 +58,7 @@ const wsLink = new WebSocketLink({
   options: {
     reconnect: true,
     connectionParams: {
-      authToken: localStorage.getItem(GC_AUTH_TOKEN),
+      authToken: localStorage.getItem(AUTH_TOKEN),
     }
   }
 })


### PR DESCRIPTION
Logout redirect should be to the root at this point in the tutorial, since the /new route doesn't exist yet.
The authToken is saved with a slightly different key in localStorage