### PR TITLE
Fix broken store updates after ch. 6

### DIFF
--- a/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
+++ b/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
@@ -132,8 +132,8 @@ Open `LinkList.js` and update the definition of `FEED_QUERY` to look as follows:
 
 ```js(path=".../hackernews-react-apollo/src/components/LinkList.js")
 export const FEED_QUERY = gql`
-  query FeedQuery($first: Int, $skip: Int, $orderBy: LinkOrderByInput) {
-    feed(first: $first, skip: $skip, orderBy: $orderBy) {
+  query FeedQuery() {
+    feed() {
       links {
         id
         createdAt

--- a/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
+++ b/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
@@ -132,8 +132,8 @@ Open `LinkList.js` and update the definition of `FEED_QUERY` to look as follows:
 
 ```js(path=".../hackernews-react-apollo/src/components/LinkList.js")
 export const FEED_QUERY = gql`
-  query FeedQuery() {
-    feed() {
+  query FeedQuery {
+    feed {
       links {
         id
         createdAt


### PR DESCRIPTION
query arguments are added too early and will cause errors on store updates at this stage: 
https://github.com/qucode1/hackernews-react-apollo#problem-4-wip

Which is caused by this apollo-client issue: https://github.com/apollographql/apollo-client/issues/2051