### PR TITLE
Update 5-applying-authentication.md

### DIFF
--- a/content/backend/graphql-js/5-applying-authentication.md
+++ b/content/backend/graphql-js/5-applying-authentication.md
@@ -265,6 +265,7 @@ Open `database/datamodel.graphql`, add a new `Vote` type and adjust the `User` a
 
 ```graphql{1-4,11,20}(path=".../hackernews-node/database/datamodel.graphql")
 type Vote {
+  id: ID! @unique
   link: Link!
   user: User!
 }


### PR DESCRIPTION
Running `yarn prisma deploy` without ID field in Vote type, the following error is thrown:
```
Writing database schema to `src/generated/prisma.graphql`  !
 ▸    VotePreviousValues fields must be an object with field names as keys or a
 ▸    function which returns such an object.
```