### PR TITLE
Fix typo

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -333,7 +333,7 @@ For example, you can send the the following `feed` query to retrieve the first 1
 }
 ```
 
-Or the `sugnup` mutation to create a new user:
+Or the `signup` mutation to create a new user:
 
 ```graphql(nocopy)
 mutation {


### PR DESCRIPTION
Small typo in the `1-getting-started` section.