### PR TITLE
Fixes typo, yarn prisma deploy command dependency

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -426,9 +426,9 @@ Another important thing to note about the Playground is that it actually allows 
 
 The first one is defined by your **application schema**, this is the one your React application will interact with. It can be opened by selecting the **default** Playground in the **app** project in the left side-menu.
 
-There also is the Prisma database API which provides full access to the data stored in the database. This one you can open by selecting the **dev** Playground in the **database** project in the left side-menu. This API is defined by the **Prisma schema** (in `server/src/generated/graphcool.graphql`).
+There also is the Prisma database API which provides full access to the data stored in the database. This one you can open by selecting the **dev** Playground in the **database** project in the left side-menu. This API is defined by the **Prisma schema** (in `server/src/generated/prisma.graphql`).
 
-> **Note**: The Playground receives the information about the two GraphQL APIs from the `.graphqlconfig.myl` file which lists the two projects **app** and **database**. That's why it can provide you access to both.
+> **Note**: The Playground receives the information about the two GraphQL APIs from the `.graphqlconfig.yml` file which lists the two projects **app** and **database**. That's why it can provide you access to both.
 
 Why do you need two GraphQL APIs at all? The answer is pretty straightforward, you can actually think of the two APIs as two _layers_.
 

--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -333,7 +333,7 @@ For example, you can send the the following `feed` query to retrieve the first 1
 }
 ```
 
-Or the `sugnup` mutation to create a new user:
+Or the `signup` mutation to create a new user:
 
 ```graphql(nocopy)
 mutation {

--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -361,12 +361,12 @@ To deploy the service all you need to do is invoke the `prisma deploy` command i
 In your terminal, navigate to the `server` directory and execute the following command:
 
 ```sh(path=".../hackernews-react-apollo/server")
-yarn prisma deploy
+yarn install && yarn prisma deploy
 ```
 
 </Instruction>
 
-Note that you can also omit `yarn` in the above command if you have the `prisma` CLI installed globally on your machine (which you can do with `npm install -g prisma`). In that case, you can simply run `prisma deploy`.
+Note that you can also omit `yarn install` and `yarn prisma` in the above command if you have the `prisma` CLI installed globally on your machine (which you can do with `npm install -g prisma`). In that case, you can simply run `prisma deploy`.
 
 <Instruction>
 

--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -361,12 +361,13 @@ To deploy the service all you need to do is invoke the `prisma deploy` command i
 In your terminal, navigate to the `server` directory and execute the following command:
 
 ```sh(path=".../hackernews-react-apollo/server")
-yarn install && yarn prisma deploy
+yarn install
+yarn prisma deploy
 ```
 
 </Instruction>
 
-Note that you can also omit `yarn install` and `yarn prisma` in the above command if you have the `prisma` CLI installed globally on your machine (which you can do with `npm install -g prisma`). In that case, you can simply run `prisma deploy`.
+Note that you can also omit `yarn prisma` in the above command if you have the `prisma` CLI installed globally on your machine (which you can do with `npm install -g prisma`). In that case, you can simply run `prisma deploy`.
 
 <Instruction>
 
@@ -406,7 +407,6 @@ With the proper Prisma endpoint in place, you can now explore the server!
 Navigate into the `server` directory and run the following commands to start the server:
 
 ```bash(path=".../hackernews-react-apollo/server")
-yarn install
 yarn dev
 ```
 


### PR DESCRIPTION
On machines without `prisma` installed, `yarn prisma deploy` won't work. 

Either `yarn install -g prisma` needs to be the prior instruction, or, my preference `yarn install` in the `server` dir, because this avoids the need to install root packages that the user may not need after they've completed the tutorial. Since `yarn install` is already needed for `yarn dev`, move `yarn install` before `yarn prisma deploy`

Also fixes the 'sugnup' and other various typos.