### PR TITLE
Update 8-subscriptions.md

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -30,6 +30,12 @@ Open a terminal and navigate to the project's root directory. Then execute the f
 yarn add apollo-link-ws
 ```
 
+> **Note**: For apollo-link-ws to work you also need to install subscriptions-transport-ws
+
+```
+yarn add subscriptions-transport-ws
+```
+
 </Instruction>
 
 Next, make sure your `ApolloClient` instance knows about the subscription server.


### PR DESCRIPTION
Added a note to inform users that the peer dependency 'subscriptions-transport-ws' needs to be installed in order for apollo-link-ws to work. This is the related issue
https://github.com/apollographql/apollo-link/issues/428