### PR TITLE
Fix error when vote for link.

### DIFF
--- a/content/frontend/vue-apollo/9-pagination.md
+++ b/content/frontend/vue-apollo/9-pagination.md
@@ -151,6 +151,26 @@ update: (store, { data: { createLink } }) => {
 }
 ```
 
+You also need to add varibles in `voteForLink` method in `LinkItem` component.
+
+Open `src/components/LinkItem.vue` and update the `updateStoreAfterVote` callback within the methods object to look like this:
+
+```js(path=".../hackernews-vue-apollo/src/components/LinkItem.vue")
+updateStoreAfterVote (store, createVote, linkId) {
+  const data = store.readQuery({
+    query: ALL_LINKS_QUERY,
+    variables: {     
+      first: 5,
+      skip: 0,
+      orderBy: 'createdAt_DESC'
+    }
+  })
+  const votedLink = data.allLinks.find(link => link.id === linkId)
+  votedLink.votes = createVote.link.votes
+  store.writeQuery({query: ALL_LINKS_QUERY, data})
+}
+```
+
 Here you are simply adding the variables that this query now expects.
 
 </Instruction>


### PR DESCRIPTION
I found a problem in `9-pagination.md`. When you vote for new link, throw the error below:
```
Error: Can't find field allLinks({}) on object (ROOT_QUERY) {
  "allLinks({\"first\":5,\"skip\":0,\"orderBy\":\"createdAt_DESC\"})": [
    {
      "type": "id",
      "id": "Link:cjennuw26npwc0153fempfgay",
      "generated": false
    },
    {
      "type": "id",
      "id": "Link:cjennn1stnkvm0111u4pj2p8j",
      "generated": false
    },
    {
      "type": "id",
      "id": "Link:cjennjzjeneci01951zxlimcj",
      "generated": false
    },
    {
      "type": "id",
      "id": "Link:cjennipflnldx0165r3eq7t4u",
      "generated": false
    },
    {
      "type": "id",
      "id": "Link:cjennhoponfvh019963yoj7eg",
      "generated": false
    }
  ],
  "_allLinksMeta": {
    "type": "id",
    "id": "$ROOT_QUERY._allLinksMeta",
    "generated": true
  }
}.
    at readStoreResolver (readFromStore.js?ee5c:43)
    at executeField (graphql.js?6f27:70)
    at eval (graphql.js?6f27:27)
    at Array.forEach (<anonymous>)
    at executeSelectionSet (graphql.js?6f27:22)
    at graphql (graphql.js?6f27:17)
    at diffQueryAgainstStore (readFromStore.js?ee5c:76)
    at readQueryFromStore (readFromStore.js?ee5c:14)
    at InMemoryCache.read (inMemoryCache.js?7265:81)
    at InMemoryCache.readQuery (inMemoryCache.js?7265:171)
```

The solve method is to add variables in query in `LinkItem.vue`.

```
      updateStoreAfterVote (store, createVote, linkId) {
        const data = store.readQuery({
          query: ALL_LINKS_QUERY,
          variables: {     //需要添加variables到LinkItem
            first: 5,
            skip: 0,
            orderBy: 'createdAt_DESC'
         }
        })
```