### PR TITLE
Fix instructions typo

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -399,7 +399,7 @@ const server = new GraphQLServer({
 
 </Instruction>
 
-> **Note**: If you ever loose the endpoint, you can get access to it again by running `yarn prisma info`.
+> **Note**: If you ever lose the endpoint, you can get access to it again by running `yarn prisma info`.
 
 #### Exploring the server
 


### PR DESCRIPTION
If you ever ~loose~ lose the endpoint