### PR TITLE
Typos/deferred resolvers

### DIFF
--- a/content/backend/graphql-scala/2-preparing-first-query.md
+++ b/content/backend/graphql-scala/2-preparing-first-query.md
@@ -297,7 +297,7 @@ val route: Route =
       getFromResource("graphiql.html")
     }
 
-```    
+```
 
 </Instruction>
 

--- a/content/backend/graphql-scala/4-deferred_resolvers.md
+++ b/content/backend/graphql-scala/4-deferred_resolvers.md
@@ -3,20 +3,20 @@ title: Deferred Resolvers
 pageTitle: "Usage of Deferred Resolvers for better performance"
 description: "In this chapter you will learn how to improve performance with deferred resolvers."
 question: "Check the correct statement about Deferred Resolvers"
-answers: ["Fetcher is higher level API for Deferred Resolver", "Deferred Resolver is of optimizing a query, Fetcher is for taking data from data source in batch","Fetcher is light version of Deferred Resolver without cache or support for relations", "Deferred Resolver and Fetcher are completely different, not related one to each other things" ]
+answers: ["Fetcher is a higher level API for Deferred Resolver", "Deferred Resolver is for optimizing a query, Fetcher is for taking data from data source in batch","Fetcher is light version of Deferred Resolver without cache or support for relations", "Deferred Resolver and Fetcher are completely different, not related to each other" ]
 correctAnswer: 0
 ---
 
 
 ### Deferred Resolvers and Fetchers
 
-`Fetcher`s and `Deferred Resolver`s are mechanisms for batch retrieval of object from their sources like database or external API. `Deferred Resolver` provides efficient, low-level API but, on the other hand, it’s more complicated in use and less secured. `Fetcher` is a specialized version of `Deferred Resolver`. It provides high-level API, it’s easier to use and usually provides all you need. It optimizes resolution of fetched entities based on its ID or relation, it deduplicates entities and caches the results, and much more.
+`Fetcher`s and `Deferred Resolver`s are mechanisms for batch retrieval of object from their sources like database or external API. `Deferred Resolver` provides an efficient, low-level API but, on the other hand, it’s more complicated to use and less secure. `Fetcher` is a specialized version of `Deferred Resolver`. It provides a high-level API, it’s easier to use and usually provides all you need. It optimizes resolution of fetched entities based on ID or relation, it deduplicates entities and caches the results, and much more.
 
-Let's implement one for `Link` entity:
+Let's implement one for the `Link` entity:
 
 <Instruction>
 
-Add definition of fetcher for link to the `GraphQLSchema` object:
+Add the fetcher definition for the `Link` entity to the `GraphQLSchema` object:
 
 ```scala
 
@@ -53,13 +53,13 @@ Field("links",
 
 We're still using `dao.getLinks` to fetch links from database, but now it's wrapped in `Fetcher`. It optimizes the query **before** call. Firstly it gathers all data it should fetch and then it executes the queries. Caching and deduplication mechanisms allow to avoid duplicated queries and give results faster.
 
-As you can see, we use the same fetcher in two fields, in the first example we're providing only single id and expecting one, optional object (`deferOpt` function). In the second case we're providing a list of ids and expecting a sequence of objects (`deferSeq`).
+As you can see, we use the same fetcher in two fields, in the first example we're providing only a single id and expecting one, optional object (`deferOpt` function). In the second case we're providing a list of ids and expecting a sequence of objects (`deferSeq`).
 
-If we have our fetcher defined, let's push it to lower level.
+Now that we have defined our fetcher, let's push it to lower level.
 
 <Instruction>
 
-In `GraphQLSchema` create constant for deferred resolver.
+In `GraphQLSchema` create a constant for the deferred resolver.
 
 ```scala
 
@@ -73,7 +73,7 @@ Such resolver have to be passed into the `Executor` to make it available for use
 
 <Instruction>
 
-Add resolver to the executor, open the `GraphQLServer.scala` file, and change `executeGraphQLQuery` function content as follows:
+Add the resolver to the executor, open the `GraphQLServer.scala` file, and change `executeGraphQLQuery` function content as follows:
 
 ```scala
 
@@ -84,25 +84,24 @@ Executor.execute(
   variables = vars,
   operationName = operation,
   deferredResolver = GraphQLSchema.Resolver
-).map(
+)
 //the rest without changes
-
 ```
 
 </Instruction>
 
-Since, we're using `DAO.getLinks` to fetch single entity or entire list, we don't need `getLink` function anymore.
+Since, we're using `DAO.getLinks` to fetch a single entity or an entire list, we don't need the `getLink` function anymore.
 
 <Instruction>
 
-Open a `DAO` class and remove `getLink` function.
+Open a `DAO` class and remove the `getLink` function.
 
 </Instruction>
 
 
 ### HasId type class
 
-If you tried to execute a query, you got an error at this point. The reason is that `Fetcher` needs 'something' what extracts ids from entities. This thing is `HasId` type class. You have few choices how to provide such class for your model. Firstly you can explicitly pass it, like this:
+If you tried to execute a query, you got an error at this point. The reason is that `Fetcher` needs 'something' what extracts ids from entities. This thing is `HasId` type class. You have a few choices on how to provide such class for your model. Firstly you can pass it explicitly, like this:
 
 ```scala
 
@@ -112,8 +111,8 @@ val linksFetcher = Fetcher(
 
 ```
 
-On the other hand. You can declare implicit constant in the same context so fetcher will take it implicitly.
-The third way is to provide `HasId` implicitly inside companion object for our model, like this:
+On the other hand, you can declare an implicit constant in the same context so the fetcher will take it implicitly.
+The third way is to provide `HasId` implicitly inside the companion object of our model, like this:
 
 ```scala
 
@@ -125,7 +124,7 @@ object Link {
 
 <Instruction>
 
-Add implicit hasId in the `GraphQLServer`
+Add an implicit hasId in `GraphQLServer`
 
 ```scala
 
@@ -138,23 +137,23 @@ implicit val linkHasId = HasId[Link, Int](_.id)
 
 ### Test it
 
-You can debug `DAO.getLinks` function in any way and execute following query:
+You can debug the `DAO.getLinks` function in any way and execute the following query:
 
 ```graphql
 
 query {
 
     l1: link(id: 1){
-    	id
-    	url
-  	}
+      id
+      url
+    }
 
   l2: link(id: 1){
-    	id
-    	url
-  	}
+      id
+      url
+    }
 
-  	links(ids: [2,3]){
+    links(ids: [2,3]){
       id
       url
     }
@@ -163,8 +162,8 @@ query {
 
 ```
 
-Even the query want the same link twice, when you'll debug it, you can see `getLinks` is called only once!
+Even though the query request the same link twice, when you debug it, you can see that `getLinks` is called only once!
 
 ### What's next?
 
-In the next chapter we will add additional field to the `Link`. We need to add an information when link is added to the best type to cover such need is date-time. H2 doesn't support the type we need so we have to manage it somehow manually. In sangria you can define your own scalar types and this is what we will learn about. 
+In the next chapter we will add an additional field to the `Link` class. We need to add information about the moment when the link is added. The best type to cover such need is date-time. H2 doesn't support the type we need so we have to manage it somehow manually. In sangria you can define your own scalar types and this is what we will learn about. 


### PR DESCRIPTION
Fixed a few typos in deferred resolvers.
Replaced tabs with spaces in code excerpts.

Also removed a few empty spaces in chapter 2