### PR TITLE
Typos/deferred resolvers and custom scalars in Scala/sangria

### DIFF
--- a/content/backend/graphql-scala/2-preparing-first-query.md
+++ b/content/backend/graphql-scala/2-preparing-first-query.md
@@ -297,7 +297,7 @@ val route: Route =
       getFromResource("graphiql.html")
     }
 
-```    
+```
 
 </Instruction>
 

--- a/content/backend/graphql-scala/4-deferred_resolvers.md
+++ b/content/backend/graphql-scala/4-deferred_resolvers.md
@@ -3,20 +3,20 @@ title: Deferred Resolvers
 pageTitle: "Usage of Deferred Resolvers for better performance"
 description: "In this chapter you will learn how to improve performance with deferred resolvers."
 question: "Check the correct statement about Deferred Resolvers"
-answers: ["Fetcher is higher level API for Deferred Resolver", "Deferred Resolver is of optimizing a query, Fetcher is for taking data from data source in batch","Fetcher is light version of Deferred Resolver without cache or support for relations", "Deferred Resolver and Fetcher are completely different, not related one to each other things" ]
+answers: ["Fetcher is a higher level API for Deferred Resolver", "Deferred Resolver is for optimizing a query, Fetcher is for taking data from data source in batch","Fetcher is light version of Deferred Resolver without cache or support for relations", "Deferred Resolver and Fetcher are completely different, not related to each other" ]
 correctAnswer: 0
 ---
 
 
 ### Deferred Resolvers and Fetchers
 
-`Fetcher`s and `Deferred Resolver`s are mechanisms for batch retrieval of object from their sources like database or external API. `Deferred Resolver` provides efficient, low-level API but, on the other hand, it’s more complicated in use and less secured. `Fetcher` is a specialized version of `Deferred Resolver`. It provides high-level API, it’s easier to use and usually provides all you need. It optimizes resolution of fetched entities based on its ID or relation, it deduplicates entities and caches the results, and much more.
+`Fetcher`s and `Deferred Resolver`s are mechanisms for batch retrieval of object from their sources like database or external API. `Deferred Resolver` provides an efficient, low-level API but, on the other hand, it’s more complicated to use and less secure. `Fetcher` is a specialized version of `Deferred Resolver`. It provides a high-level API, it’s easier to use and usually provides all you need. It optimizes resolution of fetched entities based on ID or relation, it deduplicates entities and caches the results, and much more.
 
-Let's implement one for `Link` entity:
+Let's implement one for the `Link` entity:
 
 <Instruction>
 
-Add definition of fetcher for link to the `GraphQLSchema` object:
+Add the fetcher definition for the `Link` entity to the `GraphQLSchema` object:
 
 ```scala
 
@@ -53,13 +53,13 @@ Field("links",
 
 We're still using `dao.getLinks` to fetch links from database, but now it's wrapped in `Fetcher`. It optimizes the query **before** call. Firstly it gathers all data it should fetch and then it executes the queries. Caching and deduplication mechanisms allow to avoid duplicated queries and give results faster.
 
-As you can see, we use the same fetcher in two fields, in the first example we're providing only single id and expecting one, optional object (`deferOpt` function). In the second case we're providing a list of ids and expecting a sequence of objects (`deferSeq`).
+As you can see, we use the same fetcher in two fields, in the first example we're providing only a single id and expecting one, optional object (`deferOpt` function). In the second case we're providing a list of ids and expecting a sequence of objects (`deferSeq`).
 
-If we have our fetcher defined, let's push it to lower level.
+Now that we have defined our fetcher, let's push it to lower level.
 
 <Instruction>
 
-In `GraphQLSchema` create constant for deferred resolver.
+In `GraphQLSchema` create a constant for the deferred resolver.
 
 ```scala
 
@@ -73,7 +73,7 @@ Such resolver have to be passed into the `Executor` to make it available for use
 
 <Instruction>
 
-Add resolver to the executor, open the `GraphQLServer.scala` file, and change `executeGraphQLQuery` function content as follows:
+Add the resolver to the executor, open the `GraphQLServer.scala` file, and change `executeGraphQLQuery` function content as follows:
 
 ```scala
 
@@ -84,25 +84,24 @@ Executor.execute(
   variables = vars,
   operationName = operation,
   deferredResolver = GraphQLSchema.Resolver
-).map(
+)
 //the rest without changes
-
 ```
 
 </Instruction>
 
-Since, we're using `DAO.getLinks` to fetch single entity or entire list, we don't need `getLink` function anymore.
+Since, we're using `DAO.getLinks` to fetch a single entity or an entire list, we don't need the `getLink` function anymore.
 
 <Instruction>
 
-Open a `DAO` class and remove `getLink` function.
+Open a `DAO` class and remove the `getLink` function.
 
 </Instruction>
 
 
 ### HasId type class
 
-If you tried to execute a query, you got an error at this point. The reason is that `Fetcher` needs 'something' what extracts ids from entities. This thing is `HasId` type class. You have few choices how to provide such class for your model. Firstly you can explicitly pass it, like this:
+If you tried to execute a query, you got an error at this point. The reason is that `Fetcher` needs 'something' what extracts ids from entities. This thing is `HasId` type class. You have a few choices on how to provide such class for your model. Firstly you can pass it explicitly, like this:
 
 ```scala
 
@@ -112,8 +111,8 @@ val linksFetcher = Fetcher(
 
 ```
 
-On the other hand. You can declare implicit constant in the same context so fetcher will take it implicitly.
-The third way is to provide `HasId` implicitly inside companion object for our model, like this:
+On the other hand, you can declare an implicit constant in the same context so the fetcher will take it implicitly.
+The third way is to provide `HasId` implicitly inside the companion object of our model, like this:
 
 ```scala
 
@@ -125,7 +124,7 @@ object Link {
 
 <Instruction>
 
-Add implicit hasId in the `GraphQLServer`
+Add an implicit hasId in `GraphQLServer`
 
 ```scala
 
@@ -138,23 +137,23 @@ implicit val linkHasId = HasId[Link, Int](_.id)
 
 ### Test it
 
-You can debug `DAO.getLinks` function in any way and execute following query:
+You can debug the `DAO.getLinks` function in any way and execute the following query:
 
 ```graphql
 
 query {
 
     l1: link(id: 1){
-    	id
-    	url
-  	}
+      id
+      url
+    }
 
   l2: link(id: 1){
-    	id
-    	url
-  	}
+      id
+      url
+    }
 
-  	links(ids: [2,3]){
+    links(ids: [2,3]){
       id
       url
     }
@@ -163,8 +162,8 @@ query {
 
 ```
 
-Even the query want the same link twice, when you'll debug it, you can see `getLinks` is called only once!
+Even though the query request the same link twice, when you debug it, you can see that `getLinks` is called only once!
 
 ### What's next?
 
-In the next chapter we will add additional field to the `Link`. We need to add an information when link is added to the best type to cover such need is date-time. H2 doesn't support the type we need so we have to manage it somehow manually. In sangria you can define your own scalar types and this is what we will learn about. 
+In the next chapter we will add an additional field to the `Link` class. We need to add information about the moment when the link is added. The best type to cover such need is date-time. H2 doesn't support the type we need so we have to manage it somehow manually. In sangria you can define your own scalar types and this is what we will learn about. 

--- a/content/backend/graphql-scala/5-custom_scalars.md
+++ b/content/backend/graphql-scala/5-custom_scalars.md
@@ -1,21 +1,21 @@
 ---
 title: Custom Scalars
 pageTitle: "Add Date to the Link model, make the DB and Sangria to understand this type"
-description: "In this chapter Link model will get additional field to store date and time. You will learn how to handle such custom types and use scalars."
-question: "What is a main advantage of defining custom scalar type?"
-answers: ["It adds bells and whistles to your code.", "It makes possible parse values to your type","It's only alias for basic types, there is nothing more than improving readability", "You can store data in type not supported by database." ]
+description: "In this chapter Link model will get an additional field to store date and time. You will learn how to handle such custom types and use scalars."
+question: "What is a main advantage of defining a custom scalar type?"
+answers: ["It adds bells and whistles to your code.", "It makes it possible to parse values in your type","It's only an alias for basic types, there is nothing more than improving readability", "You can store your data in a type not supported by the database." ]
 correctAnswer: 1
 
 ---
 
 ### Goal for this chapter
 
-To align to the Schema we proposed at the beginning, we have to extend a `Link` model with additional field: `createdAt`. This field will store information about date and time. The problem is that `H2` database understand only timestamp. Similar limitation has Sangria - it supports only basic types. Our goal is to store it in database and present in out in human friendly format.
+To match the schema we proposed at the beginning, we have to extend a `Link` model with an additional field: `createdAt`. This field will store information about date and time. The problem is that `H2` database understands only timestamp. Sangria has a similar limitation - it supports only basic types. Our goal is to store the date an time information in the database and present it in a human friendly format.
 
 
 ### Extend a Link model
 
-The type for storing date and time I chose is `akka.http.scaladsl.model.DateTime`. It fits to our example because it has implemented ISO Format converters. (I know it's internal model that I want to use in API, but it covers all my needs without any additional work. So I chose it, but in real, production application avoid this if you can. Java has dedicated package for date and time and it consist many classes you can use.)
+The type for storing date and time I chose is `akka.http.scaladsl.model.DateTime`. It fits our example because it has implemented ISO Format converters. (I know it's an internal model that I want to use in API, but it covers all my needs without any additional work. So I chose it, but in real, production application avoid this if you can. Java has dedicated package for date and time and it includes many classes you can use.)
 
 <Instruction>
 
@@ -25,17 +25,18 @@ Change the content of `Link.scala`:
 import akka.http.scaladsl.model.DateTime
 
 case class Link(id: Int, url: String, description: String, createdAt: DateTime)
+
 ```
 
 </Instruction>
 
-### Fix the databases
+### Fix the database
 
-In `DbSchema` we're storing few links in database, we have to add additional field now.
+In `DbSchema` we're storing a few links in database, we now have to add the additional field.
 
 <Instruction>
 
-Add `createdAt` field in `Link` models for populated example data in `DBSchema`. Change `databaseSetup` function into following code:
+Add the `createdAt` field in the `Link` models for populated example data in `DBSchema`. Change the `databaseSetup` function into the following code:
 
 ```scala
 Links forceInsertAll Seq(
@@ -51,7 +52,7 @@ Almost good, but `H2` doesn't know how to store such type in database, so we wil
 
 <Instruction>
 
-Add column mapper for our `DateTime` type in `DBSchema` object.
+Add column mapper for our `DateTime` type in `DBSchema` object (before the `LinksTable` definition).
 
 ```scala
 implicit val dateTimeColumnType = MappedColumnType.base[DateTime, Timestamp](
@@ -62,13 +63,13 @@ implicit val dateTimeColumnType = MappedColumnType.base[DateTime, Timestamp](
 
 </Instruction>
 
-This mapper will convert `DateTime` into used internally by database `Long` type which is a primitive recognized by H2.
+This mapper will convert `DateTime` into `Long`, which is a primitive recognized by H2.
 
-The last thing is to add `createdAt` column definition in table declaration.
+The last thing is to add the `createdAt` column definition in the table declaration.
 
 <Instruction>
 
-Add following code inside `LinksTable` class. Replace current `*` function with the following one.
+Add the following code inside `LinksTable` class. Replace the current `*` function with the following one.
 
 ```scala
 def createdAt = column[DateTime]("CREATED_AT")
@@ -83,13 +84,13 @@ def * = (id, url, description, createdAt) <> ((Link.apply _).tupled, Link.unappl
 
 Sangria supports all standard GraphQL scalars like `String`, `Int`, etc. In addition you can find scalars for types like `Long`, `BigInt` or `BigDecimal`. There are a lot of them, but you might encounter situations where custom or unsupported types should be used.
 Like in our example, we're using `DateTime` type, and there are no built-in scalar for such type.
-To add support for our case, we will use the same trick as with H2. We will define conversions from the type we want to type Sangria understands and the back again to our type. For our use case we will use String as the underlying type.
+To add support for our case, we will use the same trick as with H2. We will define conversions from the type we want to type Sangria understands and then back again to our type. For our use case we will use String as the underlying type.
 
-Let's write a scalar that converts `String` and `DateTime`. In both ways.
+Let's write a scalar that converts `String` to `DateTime` and vice versa.
 
 <Instruction>
 
-In `GraphQLSchema` add following code:
+In `GraphQLSchema` add the following code:
 
 ```scala
 implicit val GraphQLDateTime = ScalarType[DateTime](//1
@@ -110,16 +111,16 @@ implicit val GraphQLDateTime = ScalarType[DateTime](//1
 
 1. Use `implicit` because it implicitly has to be in scope
 1. `"DateTime"`. The name will be used in schemas.
-1. `coerceOutput` converts our type to a String. It will be used to produce output data.
-1. `coerceInput` needs partial function with `Value` as single argument. Such value could be of many types. In our case we're parsing only from `StringValue`. Of course nothing stops you from defining few conversions. If you define more cases for coerceInput users will have freedom to provide input in more ways.
+1. `coerceOutput` converts our type to a String. It will be used to produce the output data.
+1. `coerceInput` needs a partial function with `Value` as single argument. Such value could be of many types. In our case we're parsing only from `StringValue`. Of course nothing stops you from defining many conversions. If you define more cases for coerceInput, users will have the freedom to provide input in more ways.
 1. `coerceUserInput` converts Literal which almost always is a String. While this function should cover basic types, `coerceInput` and `coerceOutput` should always be a value that the GraphQL grammar supports.
 
-Both functions `coerceInput` and `coerceUserInput` should responds with `Either`. The correct (right) value should consists object of expected type. In case of failure, left value should contain `Violation` subtype. Sangria provides many `Violation` subtypes, but in the code above you can see I've used `DateTimeCoerceViolation`.
+Both functions `coerceInput` and `coerceUserInput` should respond with `Either`. The correct (right) value should consist of an object of expected type. In case of failure, the left value should contain a `Violation` subtype. Sangria provides many `Violation` subtypes, but in the code above you can see I've used `DateTimeCoerceViolation`.
 Let's implement this.
 
 <Instruction>
 
-In `GraphQLSchema` file add following definition:
+In `GraphQLSchema` file add the following definition:
 
 ```scala
   case object DateTimeCoerceViolation extends Violation {
@@ -128,9 +129,16 @@ In `GraphQLSchema` file add following definition:
 
 ```
 
+Finally, add the new field definition to the `LinkType` object:
+
+```scala
+  Field("createdAt", GraphQLDateTime, resolve = _.value.createdAt)
+
+```
 </Instruction>
 
-Now when you'll add `createAt` field to the query, you should get proper response. For example on query:
+
+Now when you'll add `createdAt` field to the query, you should get proper response. For example on query:
 
 ```graphql
 query {


### PR DESCRIPTION
Fixed a few typos in deferred resolvers and scalars.
Replaced tabs with spaces in code excerpts.

Also removed a few empty spaces in chapter 2

Added one missing instruction in scalars
