### PR TITLE
fix answer of 1-getting-started

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -4,7 +4,7 @@ pageTitle: "Getting Started with GraphQL, React & Apollo Tutorial"
 description: Start building a Hackernews clone. Create the frontend with create-react-app and the backend with Prisma.
 question: Why are there two GraphQL API layers in a backend architecture with Prisma?
 answers: ["To increase robustness and stability of the GraphQL server (if one layer fails, the server is backed by the second one).", "To increase performance of the GraphQL server (requests are accelerated  by going through multiple layers).", "Prisma provides the database layer which offers CRUD operations. The second layer is the application layer for business logic and common workflows (like authentication).", "Having two GraphQL layers is a hard requirement by the GraphQL specification."]
-correctAnswer: 3
+correctAnswer: 2
 draft: false
 videoId: ""
 duration: 0		


### PR DESCRIPTION
To my understanding the third question is correct, but the provided answer's index (correctAnswer:) seems to start with 0.
At the moment, the answer "Having two GraphQL layers is a hard requirement by the GraphQL specification" is counted as the correct one.