### PR TITLE
Schema Definition Language link

### DIFF
--- a/content/graphql/basics/2-core-concepts.md
+++ b/content/graphql/basics/2-core-concepts.md
@@ -13,9 +13,9 @@ In this chapter, you'll learn about some fundamental language constructs of Grap
 
 ### The Schema Definition Language (SDL)
 
-GraphQL has its own type system that’s used to define the _schema_ of an API. The syntax for writing schemas is called [Schema Definition Language](https://www.graph.cool/docs/faq/graphql-sdl-schema-definition-language-kr84dktnp0/) (SDL).
+GraphQL has its own type system that’s used to define the _schema_ of an API. The syntax for writing schemas is called [Schema Definition Language](http://graphql.org/learn/schema/#type-language) (SDL), also referred as "GraphQL schema language".
 
-Here is an example how we can use the SDL to define a simple type called `Person`:
+Here is an example how we can use the Schema Definition Language to define a simple type called `Person`:
 
 ```graphql(nocopy)
 type Person {


### PR DESCRIPTION
Link pointing to graph.cool is 404.

New link could either be https://blog.graph.cool/graphql-sdl-schema-definition-language-6755bcb9ce51 or https://www.graph.cool/docs/reference/database/data-modelling-eiroozae8u, but since the latter references official documentation:

>To learn more about the SDL, you can check out the official [documentation](http://graphql.org/learn/schema/#type-language)

maybe stick with the official documentation.

There is also repository with spec https://github.com/facebook/graphql/blob/master/spec