### PR TITLE
Fixed Typos and variable name

### DIFF
--- a/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
+++ b/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
@@ -51,7 +51,7 @@ function feed(parent, args, context, info) {
 
 </Instruction>
 
-If not `filter` string is provided, then the `where` object will be just an empty object and no filtering conditions will be applied by the Prisma engine when it returns the response for the `links` query.
+If no `filter` string is provided, then the `where` object will be just an empty object and no filtering conditions will be applied by the Prisma engine when it returns the response for the `links` query.
 
 In case there is a `filter` carried by the incoming `args`, you're constructing a `where` object that expresses our two filter conditions from above. This `where` argument is used by Prisma to filter out those `Link` elements that don't adhere to the specified conidtions.
 
@@ -91,7 +91,7 @@ query {
 Pagination is a tricky topic in API design. On a high-level, there are two major approaches how it can be tackled:
 
 - **Limit-Offset**: Request a specific _chunk_ of the list by providing the indices of the items to be retrieved (in fact, you're mostly providing the start index (_offset_) as well as a count of items to be retrieved (_limit_)).
-- **Cursor-based**: This pagination model is a bit more advanced. Every element in the list is associated with a unique ID (the _cursor_). Clients paginating through the list then provid the cursor of the starting element as well as a count of items to be retrieved.
+- **Cursor-based**: This pagination model is a bit more advanced. Every element in the list is associated with a unique ID (the _cursor_). Clients paginating through the list then provide the cursor of the starting element as well as a count of items to be retrieved.
 
 Prisma supports both pagination approaches (read more in the [docs](https://www.prisma.io/docs/reference/prisma-api/queries-ahwee4zaey#pagination)). In this tutorial, you're going to implement limit-offset pagination.
 
@@ -280,7 +280,7 @@ async function feed(parent, args, context, info) {
     : {}
 
   // 1
-  const queriedLinkes = await context.db.query.links(
+  const queriedLinks = await context.db.query.links(
     { where, skip: args.skip, first: args.first, orderBy: args.orderBy },
     `{ id }`,
   )
@@ -298,7 +298,7 @@ async function feed(parent, args, context, info) {
   // 3
   return {
     count: linksConnection.aggregate.count,
-    linkIds: queriedLinkes.map(link => link.id),
+    linkIds: queriedLinks.map(link => link.id),
   }
 }
 ```


### PR DESCRIPTION
 'If not filter' -> 'If no filter'
'provid' ->  'provide'
Variable 'queriedLinkes' -> 'queriedLinks'