### PR TITLE
docs(8-filtering-pagination-and-sorting): add missing selection-set

### DIFF
--- a/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
+++ b/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
@@ -154,6 +154,8 @@ query {
     skip: 1
   ) {
     id
+    description
+    url
   }
 }
 ```


### PR DESCRIPTION
Add the missing "description" and "url" selection-set fields to the
example query that result in the matching screenshot shown below the
example query.