### PR TITLE
Fixed graphcool-framework shortcut typo and 2x instructions

### DIFF
--- a/content/frontend/angular-apollo/1-getting-started.md
+++ b/content/frontend/angular-apollo/1-getting-started.md
@@ -78,7 +78,7 @@ npm install -g graphcool-framework
 
 </Instruction>
 
-To use the Graphcool CLI, you can either use the `graphcool-framework` command, or the shorter form: `gfc`.
+To use the Graphcool CLI, you can either use the `graphcool-framework` command, or the shorter form: `gcf`.
 
 Now you can go and create the server. There are two steps involved in this:
 

--- a/content/frontend/angular-apollo/2-queries-loading-links.md
+++ b/content/frontend/angular-apollo/2-queries-loading-links.md
@@ -52,6 +52,8 @@ export class LinkItemComponent implements OnInit {
 </Instruction>
 
 <Instruction>
+
+Add the following code in `link-item.component.html`:
   
 ```html(path=".../hackernews-angular-apollo/src/app/link-item/link-item.component.html")
 
@@ -225,9 +227,9 @@ Create a file within `src/app` called `graphql.ts`. This is where all of your qu
 
 <Instruction>
 
-Open up `src/constants/graphql.js` and add your first query:
+Open up `src/app/graphql.ts` and add your first query:
 
-```ts{2-3,5-15,17-21}(path=".../hackernews-vue-apollo/src/app/graphql.ts")
+```ts{2-3,5-15,17-21}(path=".../hackernews-angular-apollo/src/app/graphql.ts")
 import {Link} from './types';
 // 1
 import gql from 'graphql-tag'


### PR DESCRIPTION
1-getting-started.md
Line: 81 gfc -> gcf 
2-queries-loading-links.md
Line: 54 Added instruction text to correct the display of the Instruction for link-item.component.html. Line: 228 Corrected the path for the Instruction for graphql.ts

