### PR TITLE
[react-apollo] Spread feed object in subscription

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -164,6 +164,7 @@ updateQuery: (previous, { subscriptionData }) => {
   const result = {
     ...previous,
     feed: {
+      ...previous.feed,
       links: newAllLinks
     },
   }


### PR DESCRIPTION
Fixes #594 

Following the React + Apollo guide for graphql and encountered the issue mentioned above. Just thought I would submit this fix to clean up what is otherwise an awesome tutorial!