### PR TITLE
missing __typename property

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -164,6 +164,7 @@ updateQuery: (previous, { subscriptionData }) => {
   const result = {
     ...previous,
     feed: {
+      ...previous.feed,
       links: newAllLinks
     },
   }


### PR DESCRIPTION
function `updateQuery` tries to overwrite the store with feed object that lacks "__typename" property.

Error:
```
...
Store error: the application attempted to write an object with no provided typename but the store already contains an object with typename of Feed for the object of id $ROOT_QUERY.feed. The selectionSet that was trying to be written is:
feed {
  links {
    id
    createdAt
    url
    description
    postedBy {
      id
      name
      __typename
    }
    votes {
      id
      user {
        id
        __typename
      }
      __typename
    }
    __typename
  }
  __typename
}
    at writeFieldToStore (writeToStore.js:303)
...
```