### PR TITLE
 Fix typos

### DIFF
--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -206,7 +206,7 @@ Now on the `login` mutation:
 1. The next step is to compare the provided password with the one that is stored in the database. If the two don't match up, you're returning an error as well.
 1. In the end, you're returning `token` and `user` again.
 
-The implementation of both resolvers is relatively straighforward - nothing too surpring. The only thing that's not clear right now is the hardcoded selection set containing only the `id` field. What happens if the incoming mutation requests more information about the `User`?
+The implementation of both resolvers is relatively straighforward - nothing too surprising. The only thing that's not clear right now is the hardcoded selection set containing only the `id` field. What happens if the incoming mutation requests more information about the `User`?
 
 ### Adding the `AuthPayload` resolver
 


### PR DESCRIPTION
### Context
```js
(path=".../hackernews-node/src/resolvers/Muation.js")
```

`Muation.js` is miss-spelled an should be `Mutation.js` to link correctly.

There is also a typo `surpring` which I assume is suprosed to be `surprising`

### Changes

Fixed Typos:
- `/hackernews-node/src/resolvers/Muation.js` → `/hackernews-node/src/resolvers/Mutation.js`
- `surpring`  → `surprising`