### PR TITLE
Update file name

### DIFF
--- a/content/backend/graphql-python/4-authentication.md
+++ b/content/backend/graphql-python/4-authentication.md
@@ -123,7 +123,7 @@ To test it, send a query to the server:
 ### User Authentication
 The concept of authentication and authorization is enabled by default on Django using sessions. Since most of the web apps today are *stateless*, we are going to use the [django-graphql-jwt](https://github.com/flavors/django-graphql-jwt) library to implement [JWT Tokens](https://jwt.io/) in Graphene (thanks [mongkok](https://github.com/mongkok)!).
 
-Basically, when a User sings up or logs in a token will be returned: a piece of data that identify the User. This token must be sent by the User in the HTTP Authorization header with *every request* when authentication is needed. If you want to know more about how the token is generated, take a look at the JTW site above.
+Basically, when a User sings up or logs in a token will be returned: a piece of data that identify the User. This token must be sent by the User in the HTTP Authorization header with *every request* when authentication is needed. If you want to know more about how the token is generated, take a look at the JWT site above.
 
 Unfortunally, the GraphiQL web interface that we used before does not accept adding custom HTTP headers. From now on, we will be using the Insomnia desktop app. You can download and install it [here](https://insomnia.rest/download).
 

--- a/content/backend/graphql-python/4-authentication.md
+++ b/content/backend/graphql-python/4-authentication.md
@@ -69,7 +69,7 @@ class Query(links.schema.Query, graphene.ObjectType):
     pass
 
 
-class Mutation(users.schema.Mutation, links.schema.Mutation, graphene.ObjectType,):
+class Mutation(hackernews.users.schema.Mutation, links.schema.Mutation, graphene.ObjectType,):
     pass
 
 
@@ -91,7 +91,7 @@ Let's create a query for listing all users:
 
 On the `users/schema.py` file, add the following:
 
-```python(path=".../graphql-python/hackernews/user/schema.py")
+```python(path=".../graphql-python/hackernews/users/schema.py")
 # ...code
 class Query(graphene.ObjectType):
     users = graphene.List(UserType)
@@ -110,7 +110,7 @@ Enable the users query on the main query class:
 # ...code
 
 # Add the users.schema.Query
-class Query(users.schema.Query, links.schema.Query, graphene.ObjectType):
+class Query(hackernews.users.schema.Query, links.schema.Query, graphene.ObjectType):
     pass
 ```
 

--- a/content/backend/graphql-python/4-authentication.md
+++ b/content/backend/graphql-python/4-authentication.md
@@ -15,7 +15,7 @@ To do it so, we need to send data to the server through a mutation.
 
 Create a new folder under `hackersnews` called `users` and a new file called `schema.py`:
 
-```python(path=".../graphql-python/hackernews/user/schema.py")
+```python(path=".../graphql-python/hackernews/users/schema.py")
 from django.contrib.auth import get_user_model
 
 import graphene
@@ -62,7 +62,7 @@ Before executing it, you need to put the new mutation on the root schema file, `
 import graphene
 
 import links.schema
-import users.schema
+import hackernews.users.schema
 
 
 class Query(links.schema.Query, graphene.ObjectType):


### PR DESCRIPTION
According to the [authentication chapter](https://github.com/howtographql/howtographql/blob/master/content/backend/graphql-python/4-authentication.md) for GraphQL-Python, the file to be created for handling user creation is called `users` but it was named `user` in the chapter.