### PR TITLE
Update to create-react-app instructions

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -41,7 +41,7 @@ yarn global add create-react-app
 Next, you can use it to bootstrap your React application:
 
 ```bash
-create-react-app hackernews-react-apollo
+npx create-react-app hackernews-react-apollo
 ```
 
 </Instruction>


### PR DESCRIPTION
`npx create-react-app my-app` is the current way to create a react app with `create-react-app`. The command did not work without `npx` prepended https://github.com/facebook/create-react-app