### PR TITLE
Update 8-subscriptions.md

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -164,7 +164,8 @@ updateQuery: (previous, { subscriptionData }) => {
   const result = {
     ...previous,
     feed: {
-      links: newAllLinks
+      ...previous.feed,
+      links: newAllLinks,
     },
   }
   return result


### PR DESCRIPTION
Make a deep merge of the previous and new objects in the updateQuery method to include the previous.feed.__typename in the new state. This is to prevent an "missing typename" error which was thrown by Apollo.

Add a trailing comma for consistency.