### PR TITLE
Change name to url

### DIFF
--- a/content/backend/graphql-scala/2-preparing-first-query.md
+++ b/content/backend/graphql-scala/2-preparing-first-query.md
@@ -16,7 +16,7 @@ Our goal for this chapter is to run following query:
 query {
   allLinks {
     id
-    name
+    url
     description
   }
 }


### PR DESCRIPTION
Our Link model has id, url and description. So our Graphql's query needs to be the same unless we have some mapper between name and url.