### PR TITLE
Keep alias name consistent

### DIFF
--- a/content/backend/graphql-elixir/2-queries.md
+++ b/content/backend/graphql-elixir/2-queries.md
@@ -12,7 +12,7 @@ You're going to start by building out an empty Schema. The GraphQL API is how yo
 defmodule CommunityWeb.Schema do
   use Absinthe.Schema
 
-  alias CommunityWeb.News
+  alias CommunityWeb.NewsResolver
 
   query do
     # this is the query entry point to our app


### PR DESCRIPTION
Use `alias CommunityWeb.NewsResolver` throughout the entire article as to reduce confusion.