### PR TITLE
Add secret to Prisma instantiation

### DIFF
--- a/content/backend/graphql-js/5-connecting-server-and-database.md
+++ b/content/backend/graphql-js/5-connecting-server-and-database.md
@@ -192,6 +192,7 @@ const server = new GraphQLServer({
     db: new Prisma({
       typeDefs: 'src/generated/prisma.graphql',
       endpoint: 'https://eu1.prisma.sh/public-graytracker-771/hackernews-node/dev',
+      secret: 'mysecret123',
       debug: true,
     }),
   }),


### PR DESCRIPTION
If you do not add the secret to the Prisma instantiation, you will receive a invalid token error when running the playground locally.