### PR TITLE
return correct result from update query

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -164,6 +164,7 @@ updateQuery: (previous, { subscriptionData }) => {
   const result = {
     ...previous,
     feed: {
+      ...previous.feed,
       links: newAllLinks
     },
   }


### PR DESCRIPTION
The result returned from updateQuery needs to include `__typename`. 

![image](https://user-images.githubusercontent.com/3619060/42727186-bef3ca6a-8756-11e8-9e39-7b5beba47c8c.png)
