### PR TITLE
react-apollo -> 9-pagination -> use page variable in LinkList render

### DIFF
--- a/content/frontend/react-apollo/9-pagination.md
+++ b/content/frontend/react-apollo/9-pagination.md
@@ -168,7 +168,7 @@ Next, you need functionality for the user to switch between the pages. First add
 
 Open `LinkList.js` and update `render` to look as follows:
 
-```js{11-13,26-31}(path=".../hackernews-react-apollo/src/components/LinkList.js")
+```js{11-13,22,27-31}(path=".../hackernews-react-apollo/src/components/LinkList.js")
 render() {
 
   if (this.props.feedQuery && this.props.feedQuery.loading) {

--- a/content/frontend/react-apollo/9-pagination.md
+++ b/content/frontend/react-apollo/9-pagination.md
@@ -190,7 +190,7 @@ render() {
           <Link
             key={link.id}
             updateStoreAfterVote={this._updateCacheAfterVote}
-            index={index}
+            index={page ? (page - 1) * LINKS_PER_PAGE + index : index}
             link={link}
           />
         ))}


### PR DESCRIPTION
The chapter doc introduces a new `page` variable in the `LinkList` render method, but does not use it.

Looks like this was lost during cleanup https://github.com/howtographql/howtographql/commit/2861ab586f262fff3e731b1ec4769b90c0fe1284#diff-91fb0d2d55de547d77b567a150dfe160L188, so this change is already consistent with [sample project solution](https://github.com/howtographql/react-apollo/blob/980e18a75b8eb89c24ea5c8798514efe0b7044d0/src/components/LinkList.js#L32).

Before:
<img width="863" alt="screen shot 2018-07-17 at 4 16 46 pm" src="https://user-images.githubusercontent.com/12436887/42850542-fe3bcd20-89dc-11e8-9a8b-d6a879875c53.png">

After:
<img width="860" alt="screen shot 2018-07-17 at 4 13 01 pm" src="https://user-images.githubusercontent.com/12436887/42850541-fe181eca-89dc-11e8-8249-648419eafa34.png">