### PR TITLE
Fix broken subscription updateQuery

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -164,6 +164,7 @@ updateQuery: (previous, { subscriptionData }) => {
   const result = {
     ...previous,
     feed: {
+      ...previous.feed,
       links: newAllLinks
     },
   }


### PR DESCRIPTION
The subscription updateQuery needs to not just recreate the previous store shape, but to actually inherit it's properties. By not copying those properties, essential properties were being missed and the shape of the store was changing. This meant that the store update was failing.