### PR TITLE
Clarify that the return is within Query component

### DIFF
--- a/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
+++ b/content/frontend/react-apollo/6-more-mutations-and-updating-the-store.md
@@ -115,9 +115,11 @@ Finally, each `Link` element will also render its position inside the list, so y
 
 <Instruction>
 
-Open `LinkList.js` and update the rendering of the `Link` components inside `render` to also include the link's position:
+Open `LinkList.js` and update the rendering of the `Link` components inside the `<Query>` component in `render` to also include the link's position:
 
 ```js(path=".../hackernews-react-apollo/src/components/LinkList.js")
+// <Query query={FEED_QUERY}>
+// ...
 return (
   <div>
     {linksToRender.map((link, index) => (
@@ -125,6 +127,8 @@ return (
     ))}
   </div>
 )
+// ...
+// </Query>
 ```
 
 </Instruction>


### PR DESCRIPTION
The suggested change to the Link component at first suggests that it should replace the entire return of the render function. By clarifying that it is within the Query component, it should make it more obvious that it is just the return of the Query component that is replaced.