### PR TITLE
react-apollo/1-getting-started/  documentaion fix

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -384,7 +384,9 @@ Note that you can also omit `yarn prisma` in the above command if you have the `
 
 <Instruction>
 
-When prompted where (i.e. to which cluster) you want to deploy your service, choose any of the development clusters, e.g. `public-us1` or `public-eu1`. (If you have Docker installed, you can also deploy locally.)
+When prompted where (i.e. to which _Prisma server_) you want to deploy your service, choose the **Demo server** which can be used for free in Prisma Cloud. If you haven't done so already, you will be asked to register with Prisma Cloud (which you can do via GitHub). For the following prompts in the terminal you can select the suggested values by hitting **Enter**.
+
+When prompted where (i.e. to which cluster) you want to deploy your service, choose any of the development clusters, e.g. `public-us1` or `public-eu1`. (If you have Docker installed, you can also choose to deploy Prisma locally by _Creating a new database_.)
 
 </Instruction>
 


### PR DESCRIPTION
Hi there, 
On the `prisma deploy` section - I couldn't figure out why I'm not being prompted with the choice of development clusters until I came by this useful piece of documentation which explained I first need to choose the **Demo server** option and to register with Prisma Cloud:

https://github.com/howtographql/react-apollo/blob/master/README.md

So I thought it should be included in the main documentation as well.

Thanks for this awesome project!