### PR TITLE
Update README.md, fix git clone command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ As the whole project is open-source, you're more than welcome to fix typos and o
 You can run a local instance of How to GraphQL by executing the following commands in a terminal:
 
 ```sh
-git clone git@github.com:howtographql/howtographql.git
+git clone https://github.com/howtographql/howtographql
 cd howtographql
 yarn install
 yarn start # http://localhost:8000/


### PR DESCRIPTION
The error due to existing cmd

> Cloning into 'howtographql'...
> ssh: Could not resolve hostname github.com: Name or service not known
> fatal: Could not read from remote repository.
> 
> Please make sure you have the correct access rights
> and the repository exists.

updating to `git clone https://github.com/howtographql/howtographql` fixes the issue