### PR TITLE
Fix link to referenced GraphQL Bindings article

### DIFF
--- a/content/backend/graphql-js/4-adding-a-database.md
+++ b/content/backend/graphql-js/4-adding-a-database.md
@@ -32,7 +32,7 @@ Prisma solves this problem by providing you with a _GraphQL query engine_ which 
 
 > **Note**: Prisma bindings are based on the idea of schema stitching and schema delegation. We're not going to cover these techniques in detail in this tutorial. If you want to learn more about them, you can check out the following two articles:
 > - [GraphQL Schema Stitching explained: Schema Delegation](https://blog.graph.cool/graphql-schema-stitching-explained-schema-delegation-4c6caf468405)
-> - [Reusing & Composing GraphQL APIs with GraphQL Bindings](https://blog.graph.cool/reusing-composing-graphql-apis-with-graphql-bindings-80a4aa37cff5)
+> - [Reusing & Composing GraphQL APIs with GraphQL Bindings](https://www.prisma.io/blog/reusing-and-composing-graphql-apis-with-graphql-bindings-80a4aa37cff5/)
 
 ### Architecture
 


### PR DESCRIPTION
Change a link that was previously pointing to graph.cool and returning a 404 to the correct prisma.io URL