### PR TITLE
Remove transparency to images in basic tutorial and add white background

### DIFF
--- a/content/graphql/basics/0-introduction.md
+++ b/content/graphql/basics/0-introduction.md
@@ -56,7 +56,7 @@ In fact, GraphQL is a technology that can be used everywhere a client communicat
 
 Today, GraphQL is used in production by [lots of different companies](http://graphql.org/users/) such as GitHub, Twitter, Yelp and Shopify - to name only a few.
 
-![](http://imgur.com/YZHGCzJ.png)
+![](https://imgur.com/2RYRYB3.png)
 *Despite being such a young technology, GraphQL has already been widely adopted. Learn [who else](http://graphql.org/users/) is using GraphQL in production.*
 
 There are entire conferences dedicated to GraphQL such as [GraphQL Summit](https://summit.graphql.com/) or [GraphQL Europe](https://graphql-europe.org/) and more resources like the [GraphQL Radio](https://graphqlradio.com/) podcast and [GraphQL Weekly](https://graphqlweekly.com/) newsletter.

--- a/content/graphql/basics/1-graphql-is-the-better-rest.md
+++ b/content/graphql/basics/1-graphql-is-the-better-rest.md
@@ -22,12 +22,12 @@ To illustrate the major differences between REST and GraphQL when it comes to fe
 
 With a REST API, you would typically gather the data by accessing multiple endpoints. In the example, these could be `/users/<id>` endpoint to fetch the initial user data. Secondly, there's likely to be a `/users/<id>/posts` endpoint that returns all the posts for a user. The third endpoint will then be the `/users/<id>/followers` that returns a list of followers per user.
 
-![](http://imgur.com/VIWd5I5.png)
+![](https://imgur.com/VRyV7Jh.png)
 *With REST, you have to make three requests to different endpoints to fetch the required data. You're also _overfetching_ since the endpoints return additional information that's not needed.*
 
 In GraphQL on the other hand, you'd simply send a single query to the GraphQL server that includes the concrete data requirements. The server then responds with a JSON object where these requirements are fulfilled.
 
-![](http://imgur.com/uY50GHz.png)
+![](https://imgur.com/z9VKnHs.png)
 *Using GraphQL, the client can specify exactly the data it needs in a _query_. Notice that the _structure_ of the server's response follows precisely the nested structure defined in the query.*
 
 ### No more Over- and Underfetching

--- a/content/graphql/basics/3-big-picture.md
+++ b/content/graphql/basics/3-big-picture.md
@@ -31,7 +31,7 @@ It's important to note that GraphQL is actually *transport-layer agnostic*. This
 
 GraphQL also doesn't care about the database or the format that is used to store the data. You could use a SQL database like [AWS Aurora](https://aws.amazon.com/rds/aurora) or a NoSQL database like [MongoDB](https://www.mongodb.com/). 
 
-![](http://imgur.com/kC0cFk7.png)
+![](https://imgur.com/cRE6oeb.png)
 *A standard greenfield architecture with one GraphQL server that connects to a single database.*
 
 
@@ -43,7 +43,7 @@ In that context, GraphQL can be used to *unify* these existing systems and hide 
 
 Just like in the previous architecture where the GraphQL server didn't care about the type of database being used, this time it doesn't care about the data sources that it needs to fetch the data that's needed to *resolve* a query.
 
-![](http://imgur.com/168FvP4.png)
+![](https://imgur.com/zQggcSX.png)
 *GraphQL allows you to hide the complexity of existing systems, such as microservices, legacy infrastructures or third-party APIs behind a single GraphQL interface.*
 
 #### 3. Hybrid approach with connected database and integration of existing system
@@ -52,7 +52,7 @@ Finally, it's possible to combine the two approaches and build a GraphQL server 
 
 When a query is received by the server, it will resolve it and either retrieve the required data from the connected database or some of the integrated APIs.
 
-![](http://imgur.com/oOVYriG.png)
+![](https://imgur.com/73dByTz.png)
 *Both approaches can also be combined and the GraphQL server can fetch data from a single database as well as from an existing system - allowing for complete flexibility and pushing all data management complexity to the server.*
 
 ### Resolver Functions
@@ -63,7 +63,7 @@ As you learned in the previous chapter, the payload of a GraphQL query (or mutat
 
 When the server receives a query, it will call all the functions for the fields that are specified in the query's payload. It thus *resolves* the query and is able to retrieve the correct data for each field. Once all resolvers returned, the server will package data up in the format that was described by the query and send it back to the client.
 
-![](http://imgur.com/cP2i8Da.png)
+![](https://imgur.com/e1gBEP5.png)
 *Each field in the query corresponds to a [resolver function](http://graphql.org/learn/execution/#root-fields-resolvers). The GraphQL calls all required resolvers when a query comes in to fetch the specified data.*
 
 ###  GraphQL Client Libraries


### PR DESCRIPTION
Images in the basic tutorial have been modified to add a white background. This way, content is visible when reading using -Reader mode- with a dark background.

PNG format is kept.