### PR TITLE
Update example code to latest version of `create-react-app` boilerplate

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -91,7 +91,7 @@ Your project structure should now look as follows:
 │   │   └── App.js
 │   ├── index.js
 │   ├── logo.svg
-│   ├── registerServiceWorker.js
+│   ├── serviceWorker.js
 │   └── styles
 │       ├── App.css
 │       └── index.css
@@ -209,7 +209,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import './styles/index.css'
 import App from './components/App'
-import registerServiceWorker from './registerServiceWorker'
+import * as serviceWorker from './serviceWorker'
 import { ApolloProvider } from 'react-apollo'
 import { ApolloClient } from 'apollo-client'
 import { createHttpLink } from 'apollo-link-http'
@@ -230,7 +230,7 @@ ReactDOM.render(
   </ApolloProvider>,
   document.getElementById('root')
 )
-registerServiceWorker()
+serviceWorker.unregister()
 ```
 
 </Instruction>

--- a/content/frontend/react-relay/1-getting-started.md
+++ b/content/frontend/react-relay/1-getting-started.md
@@ -278,7 +278,7 @@ Your project structure should now look as follows:
 │   │   └── App.js
 │   ├── index.js
 │   ├── logo.svg
-│   ├── registerServiceWorker.js
+│   ├── serviceWorker.js
 │   └── styles
 │       ├── App.css
 │       └── index.css

--- a/meta/writing-guidelines.md
+++ b/meta/writing-guidelines.md
@@ -147,7 +147,7 @@ You're also able to highlight individual lines inside of a code block to put emp
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
-import registerServiceWorker from './registerServiceWorker'
+import * as serviceWorker from './serviceWorker'
 import './index.css'
 // 1
 import { ApolloProvider, createNetworkInterface, ApolloClient } from 'react-apollo'


### PR DESCRIPTION
This PR updates code examples in the tutorials to reflect recent changes made in the `create-react-app` (v 2.0.4) boilerplate. Namely the following two changes:

- Rename the `registerServiceWorker.js` file to `serviceWorker.js`
- Update the usage of this module in `index.js` to match that created by the `create-react-app`.

I believe that this will help reduce errors and confusion for newer developers that are following the tutorials and install the latest version of `create-react-app`. Let me know if there are any changes that I missed. Thanks!

P.S. I will next look at updating `create-react-app` and relevant example code in the `react-apollo` and `react-relay` projects.