### PR TITLE
graphql-python - fixed user model error

### DIFF
--- a/content/backend/graphql-python/4-authentication.md
+++ b/content/backend/graphql-python/4-authentication.md
@@ -208,7 +208,7 @@ class Query(graphene.AbstractType):
     users = graphene.List(UserType)
 
     def resolve_users(self, info):
-        return User.objects.all()
+        return get_user_model().objects.all()
 
     def resolve_me(self, info):
         user = info.context.user


### PR DESCRIPTION
fixed user model which causes error:
```json
{
  "errors": [
    {
      "message": "name 'User' is not defined",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "users"
      ]
    }
  ],
  "data": {
    "users": null
  }
}
```
when querying:
```graphql
query {
  users {
    id
    username
    email
  }
}
```