### PR TITLE
graphql-python - fix for issue #743

### DIFF
--- a/content/backend/graphql-python/1-getting-started.md
+++ b/content/backend/graphql-python/1-getting-started.md
@@ -39,7 +39,7 @@ The tool used to manage Python packages is `pip`, which should be available with
 With the virtual environment activated, run the following commands:
 
 ```bash
-pip install django==2.0.2 graphene==2.0.1 graphene-django==2.0.0 django-filter==1.1.0 django-graphql-jwt==0.1.5
+pip install django==2.1.4 graphene-django==2.2.0 django-filter==2.0.0 django-graphql-jwt==0.1.5
 django-admin startproject hackernews
 cd hackernews
 python manage.py migrate


### PR DESCRIPTION
fixes #743 

note: also updated to the latest Django release (2.1.4 at this time, which I used to follow the tutorial) and removed explicit installation of `graphene` because it is installed as a dependency when installing `graphene-django`.