### PR TITLE
react-apollo/1-getting-started deploy instructions too brief #777

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -384,7 +384,11 @@ Note that you can also omit `yarn prisma` in the above command if you have the `
 
 <Instruction>
 
-When prompted where (i.e. to which cluster) you want to deploy your service, choose any of the development clusters, e.g. `public-us1` or `public-eu1`. (If you have Docker installed, you can also deploy locally.)
+The prisma deploy command starts an interactive process:
+
+First select the Demo server from the options provided. When the browser opens, register with Prisma Cloud and go back to your terminal.
+
+Then you need to select the region for your demo server. Once that’s done, you can just hit enter twice to use the suggested values for service and stage.
 
 </Instruction>
 


### PR DESCRIPTION
A PR for [this issue.](https://github.com/howtographql/howtographql/issues/777)

Added a clarification step inside `content/frontend/react-apollo/1-getting-started.md` when `prisma deploy` prompts the user to set up a new Prisma server or deploy to an existing server.

The instructions on [this page](https://www.howtographql.com/graphql-js/4-adding-a-database/) fixed all the confusion when I was prompted so I added that in. I deleted the previous instruction because I thought that selecting a region was a simpler explanation.

Thanks for such a great tutorial on GraphQL, I've learned tons!