### PR TITLE
fix: code of link subscription

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -141,15 +141,13 @@ In one Playground, send the following subscription:
 ```graphql
 subscription {
   newLink {
-    node {
+    id
+    url
+    description
+    postedBy {
       id
-      url
-      description
-      postedBy {
-        id
-        name
-        email
-      }
+      name
+      email
     }
   }
 }


### PR DESCRIPTION
the query in subscription `backend/graphql-js/7-subscriptions.md`  was wrong, 

btw the screenshot of the playground had the right query so updated the query according to it. 