### PR TITLE
Fixed broken link to GraphQL Relay Specification

### DIFF
--- a/content/backend/graphql-python/10-summary.md
+++ b/content/backend/graphql-python/10-summary.md
@@ -15,7 +15,7 @@ If you want to go deeper into GraphQL, here are some must click links:
 * [Learn GraphQL](http://graphql.org/learn/) - learn about GraphQL, how it works, and how to use it.
 * [GraphQL Weekly](https://graphqlweekly.com/) - sign up for an amazing weekly email about GraphQL.
 * [Lessons from 4 Years of GraphQL](https://www.youtube.com/watch?v=zVNrqo9XGOs) - how GraphQL has evolved inside Facebook.
-* [GraphQL Relay Specification](https://facebook.github.io/relay/docs/graphql-relay-specification.html) - title self descriptive.
+* [GraphQL Relay Specification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html) - title self descriptive.
 
 Any feedback, please drop me a [tweet](https://twitter.com/jonatasbaldin).
 


### PR DESCRIPTION
Same fix as previous PR #858 for the `10-summary.md` document this time.

Same as with file [`9-relay.md`](https://github.com/howtographql/howtographql/pull/858/files#diff-01028a0f958f43612aee56719f03e47f)