### PR TITLE
Fix typo in 7-subscriptions.md

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -141,15 +141,13 @@ In one Playground, send the following subscription:
 ```graphql
 subscription {
   newLink {
-    node {
+    id
+    url
+    description
+    postedBy {
       id
-      url
-      description
-      postedBy {
-        id
-        name
-        email
-      }
+      name
+      email
     }
   }
 }


### PR DESCRIPTION
Fix typo in the newLink subscription that includes node {}.