### PR TITLE
was not able to find where to find the gql.

### DIFF
--- a/content/frontend/react-apollo/2-queries-loading-links.md
+++ b/content/frontend/react-apollo/2-queries-loading-links.md
@@ -156,7 +156,7 @@ In general, the process for you to add some data fetching logic will be very sim
 
 <Instruction>
 
-Open up `LinkList.js` and add the query to the top of the file:
+Open up `LinkList.js`, import gql from 'graphql-tag' and add the query to the top of the file:
 
 ```js(path=".../hackernews-react-apollo/src/components/LinkList.js")
 const FEED_QUERY = gql`


### PR DESCRIPTION
was not able to find where to find the gql when taking a look into the document. Had to go and check GitHub code to figure it out. It would be better if we mention from where to import gql in the docs itself.