### PR TITLE
Change a code segment in graphql-java 3-mutations.md

### DIFF
--- a/content/backend/graphql-java/3-mutations.md
+++ b/content/backend/graphql-java/3-mutations.md
@@ -68,12 +68,13 @@ Notice how the `createLink` method, that will act as the resolver function for t
 Finally, register this new resolver the same way you registered `Query` inside `GraphQLEndpoint#buildSchema`:
 
 ```java(path=".../hackernews-graphql-java/src/main/java/com/howtographql/hackernews/GraphQLEndpoint.java")
-private static GraphQLSchema buildSchema(LinkRepository linkRepository) {
+private static GraphQLSchema buildSchema() {
+    LinkRepository linkRepository = new LinkRepository();
     return SchemaParser.newParser()
-        .file("schema.graphqls")
-        .resolvers(new Query(linkRepository), new Mutation(linkRepository))
-        .build()
-        .makeExecutableSchema();
+	.file("schema.graphqls")
+	.resolvers(new Query(linkRepository), new Mutation(linkRepository))
+	.build()
+	.makeExecutableSchema();
 }
 ```
 


### PR DESCRIPTION
### Purpose
The documentation says to register the new resolver Mutation as below.
![image](https://user-images.githubusercontent.com/25246848/51097540-ec8d9a80-17ea-11e9-842f-1580b6271e35.png)

But if I do like above, it gives an error like below in my code near buildSchema().
![image](https://user-images.githubusercontent.com/25246848/51097561-121aa400-17eb-11e9-8989-c214a88ad240.png)

### Proposed Solution
I think the code segment in the documentation should change like below. 
```
private static GraphQLSchema buildSchema() {
        LinkRepository linkRepository = new LinkRepository();
        return SchemaParser.newParser()
                .file("schema.graphqls")
                .resolvers(new Query(linkRepository), new Mutation(linkRepository))
                .build()
                .makeExecutableSchema();
    }
```
Reference the Git issue at https://github.com/howtographql/howtographql/issues/864
