### PR TITLE
Broken graphql-up link in 2-core-concepts

### DIFF
--- a/content/graphql/basics/2-core-concepts.md
+++ b/content/graphql/basics/2-core-concepts.md
@@ -9,7 +9,7 @@ videoId: NeQfq0U5LnI
 duration: 15
 ---
 
-In this chapter, you'll learn about some fundamental language constructs of GraphQL. That includes a first glimpse at the syntax for defining _types_ as well as sending _queries_ and _mutations_. We also prepared a sandbox environment for you, based on [graphql-up](https://github.com/graphcool/graphql-up), that you can use to experiment with what you learn.  
+In this chapter, you'll learn about some fundamental language constructs of GraphQL. That includes a first glimpse at the syntax for defining _types_ as well as sending _queries_ and _mutations_. We also prepared a sandbox environment for you, based on [graphql-up](https://www.npmjs.com/package/graphql-up), that you can use to experiment with what you learn.  
 
 ### The Schema Definition Language (SDL)
 


### PR DESCRIPTION
As the title states the link to graphql-up is broken but the NPM package is still available.