### PR TITLE
ruby formatting closes #891

### DIFF
--- a/content/backend/graphql-ruby/2-queries.md
+++ b/content/backend/graphql-ruby/2-queries.md
@@ -63,6 +63,22 @@ module Types
 end
 ```
 
+You'll need to add another file `app/graphql/types/date_time_type.rb` to provide a type for the created_at field for LinkType:
+
+```ruby(path=".../graphql-ruby/app/graphql/types/date_time_type.rb")
+module Types
+  class DateTimeType < GraphQL::Schema::Scalar
+    def self.coerce_input(value, _context)
+      Time.zone.parse(value)
+    end
+
+    def self.coerce_result(value, _context)
+      value.utc.iso8601
+    end
+  end
+end
+```
+
 </Instruction>
 
 ### Query Resolver

--- a/content/backend/graphql-ruby/3-mutations.md
+++ b/content/backend/graphql-ruby/3-mutations.md
@@ -47,11 +47,20 @@ For this purpose, you'll use a [Mutation class](http://graphql-ruby.org/mutation
 
 <Instruction>
 
-Create a new file - `app/graphql/mutations/create_link.rb`:
+Create a new file - `app/graphql/mutations/base_mutation.rb`:
+
+```ruby(path=".../graphql-ruby/app/graphql/mutations/base_mutation.rb")
+module Mutations
+  class BaseMutation < GraphQL::Schema::Mutation
+    null false
+  end
+end
+```
+
+and another new file - `app/graphql/mutations/create_link.rb`:
 
 ```ruby(path=".../graphql-ruby/app/graphql/mutations/create_link.rb")
 module Mutations
-  # `BaseMutation` was created from `rails generate graphql:install`
   class CreateLink < BaseMutation
     # arguments passed to the `resolved` method
     argument :description, String, required: true

--- a/content/backend/graphql-ruby/3-mutations.md
+++ b/content/backend/graphql-ruby/3-mutations.md
@@ -65,6 +65,7 @@ module Mutations
         description: description,
         url: url,
       )
+    end
   end
 end
 ```

--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -361,7 +361,7 @@ module Mutations
       crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base.byteslice(0..31))
       token = crypt.encrypt_and_sign("user-id:#{ user.id }")
 
-      ctx[:session][:token] = token
+      context[:session][:token] = token
 
       # ...code
     end


### PR DESCRIPTION
fixes:
1. Missing `end` keyword in `resolve` function in [3-mutations.md](https://github.com/howtographql/howtographql/blob/master/content/backend/graphql-ruby/3-mutations.md).  re https://github.com/howtographql/howtographql/issues/891
2.  `rails generate graphql:install` does not generate DateTimeType or BaseMutation. re https://github.com/howtographql/howtographql/issues/891
3. `ctx` is undefined, use context. re https://github.com/howtographql/howtographql/issues/104