### PR TITLE
fix link search spec

### DIFF
--- a/content/backend/graphql-ruby/7-filtering.md
+++ b/content/backend/graphql-ruby/7-filtering.md
@@ -165,5 +165,12 @@ You can run the tests with the following command:
 bundle exec rails test
 ```
 
+In order to get it to pass, you'll need to add the following line to the `Link` model.
+
+```ruby(path=".../graphql-ruby/app/models/link.rb")
+scope :like, ->(field, value) { where arel_table[field].matches("%#{value}%") }
+```
+
+
 </Instruction>
 


### PR DESCRIPTION
NoMethodError: undefined method `like' for #<Link::ActiveRecord_Relation:0x00005633b5577ad0>

