### PR TITLE
Fix bcrypt sentence so it is grammatically correct

### DIFF
--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -40,7 +40,7 @@ end
 
 Now we have users, which are required to have `name` and `email`.
 
-They also have a [secure password](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password). But in order for [has_secure_password](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password), [bcrypt](https://rubygems.org/gems/bcrypt) gem. It used encrypting and verifying user passwords.
+They also have a [secure password](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password). The [has_secure_password](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password) requires the [bcrypt](https://rubygems.org/gems/bcrypt) gem to encrypt and verify user passwords.
 
 <Instruction>
 


### PR DESCRIPTION
I think there were some typos made in the original text:

> But in order for has_secure_password, bcrypt gem.  It used encrypting and verifying user passwords.