### PR TITLE
Fix small typo on Ruby authentication page

### DIFF
--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -44,7 +44,7 @@ They also have a [secure password](http://api.rubyonrails.org/classes/ActiveMode
 
 <Instruction>
 
-Add `Gemfile` the following line:
+Add the following line to your `Gemfile`:
 
 ```ruby(path=".../graphql-ruby/Gemfile")
 gem 'bcrypt', '~> 3.1.7'


### PR DESCRIPTION
I think there was a typo here :

> Add `Gemfile` the following line: