### PR TITLE
Updated react-apollo/8-subscriptions

### DIFF
--- a/content/frontend/react-apollo/8-subscriptions.md
+++ b/content/frontend/react-apollo/8-subscriptions.md
@@ -224,7 +224,6 @@ Awesome, that's it! You can test your implementation by opening two browser wind
 
 > **ATTENTION**: There's a currently a [bug](https://github.com/apollographql/apollo-link/issues/428) in the `apollo-link-ws` package that will prevent your app from running due to the following error: `Module not found: Can't resolve 'subscriptions-transport-ws' in '/.../hackernews-react-apollo/node_modules/apollo-link-ws/lib'`
 > The workaround until it's fixed is to manually install the `subscriptions-transport-ws` package with `yarn add subscriptions-transport-ws`.
-> There's also another [bug](https://github.com/graphcool/graphql-yoga/issues/101) in `graphql-yoga` which causes the subscription to fire multiple times (while the link is in fact only created once). After reloading the site, you'll see the correct number of links.
 
 ### Subscribing to new votes
 


### PR DESCRIPTION
Removing the note related to a bug with `node-yoga`, as the bug now has been fixed
https://github.com/prisma/graphql-yoga/issues/101.