### PR TITLE
Update 1-getting-started.md

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -217,7 +217,7 @@ import './styles/index.css'
 import App from './components/App'
 import * as serviceWorker from './serviceWorker';
 import { ApolloProvider } from 'react-apollo'
-import { ApolloClient } from 'apollo-client'
+import ApolloClient from 'apollo-boost';
 import { createHttpLink } from 'apollo-link-http'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 


### PR DESCRIPTION
Was going through your tutorial and it looks like ApolloClient is now default exported from 'apollo-boost'