### PR TITLE
fixed Compilation error in lib/community_web/schema.ex

### DIFF
--- a/content/backend/graphql-elixir/2-queries.md
+++ b/content/backend/graphql-elixir/2-queries.md
@@ -53,8 +53,14 @@ Absinthe Schemas are also type checked at compile time. If you refer to a type t
 The query is now defined, but the server still doesn't know how to handle it. To do that you will now write your first **resolver**. Resolvers are just functions mapped to GraphQL fields, with their actual behavior. You specify the field for a resolver by using the resolve macro and passing it a function:
 
 ```elixir(path=".../graphql-elixir/lib/community_web/schema.ex")
-field :all_links, non_null(list_of(non_null(:link))) do
-  resolve &NewsResolver.all_links/3
+
+object :link do
+  field :id, non_null(:id)
+  field :url, non_null(:string)
+  field :description, non_null(:string)
+  field :all_links, non_null(list_of(non_null(:link))) do
+    resolve &NewsResolver.all_links/3
+  end
 end
 ```
 


### PR DESCRIPTION
== Compilation error in file lib/community_web/schema.ex ==
** (Absinthe.Schema.Notation.Error) Invalid schema notation: `field` must only be used within `input_object`, `interface`, `object`

So i moved field :all_links, non_null(list_of(non_null(:link))) in :link object