### PR TITLE
Update 1-getting-started.md

### DIFF
--- a/content/backend/graphql-elixir/1-getting-started.md
+++ b/content/backend/graphql-elixir/1-getting-started.md
@@ -49,6 +49,15 @@ In order to support GraphQL your application needs some additional dependencies 
 {:absinthe_plug, "~> 1.3.0"},
 ```
 
+Also, replace the `{:cowboy, "~> 1.0"}` dependency with `{:plug_cowboy, "~> 1.0"}` in your project’s mix.exs:
+
+```elixir(path=".../graphql-elixir/mix.exs")
+{:absinthe_ecto, "~> 0.1.0"},
+{:absinthe_plug, "~> 1.3.0"},
+{:plug_cowboy, "~> 1.0"},
+```
+
+
 <Instruction>
 
 Then run


### PR DESCRIPTION
While following the next tutorial: [2-queries](https://www.howtographql.com/graphql-elixir/2-queries/), I have to change the `{:cowboy, "~> 1.0"}` dependency with `{:plug_cowboy, "~> 1.0"}` otherwise the app won't start:

```
** (Mix) Could not start application community: Community.Application.start(:normal, []) returned an error: shutdown: failed to start child: CommunityWeb.Endpoint
```