### PR TITLE
Change correct answer value of node tutorial 

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -4,7 +4,7 @@ pageTitle: "Realtime GraphQL Subscriptions with Node.JS Tutorial"
 description: "Learn how to implement GraphQL subscriptions with Node.js, Express & Prisma to add realtime functionality to an app."
 question: Which of the following statements is true?
 answers: ["Subscriptions follow a request-response-cycle", "Subscriptions are best implemented with MailChimp", "Subscriptions are typically implemented via WebSockets", "Subscriptions are defined on the 'Query' type and annotated with the @realtime-directive"]
-correctAnswer: 3
+correctAnswer: 2
 ---
 
 In this section, you'll learn how you can bring realtime functionality into your app by implementing GraphQL subscriptions. The goal is to implement two subscriptions to be exposed by your GraphQL server:


### PR DESCRIPTION
This PR changes the correct answer of the quiz in the [**Subscriptions**](https://www.howtographql.com/graphql-js/7-subscriptions/) lesson. This is because in the tutorial there is no indication of the usage of  `@realtime-directive`. But there is explicitly said that Subscriptions are usually implemented with WebSockets.

![graphql-subscriptions](https://user-images.githubusercontent.com/29575744/57197133-70ea6180-6f31-11e9-9bd9-a5a63068571a.png)
![7-subscriptions-quiz](https://user-images.githubusercontent.com/29575744/57197213-9461dc00-6f32-11e9-9734-7d88aa2583b3.png)


Thus the correct answer is set to `2` which is _"Subscriptions are typically implemented via WebSockets"_.
