### PR TITLE
Clarify variable name

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -291,11 +291,11 @@ async function vote(parent, args, context, info) {
   const userId = getUserId(context)
 
   // 2
-  const linkExists = await context.prisma.$exists.vote({
+  const voteExists = await context.prisma.$exists.vote({
     user: { id: userId },
     link: { id: args.linkId },
   })
-  if (linkExists) {
+  if (voteExists) {
     throw new Error(`Already voted for link: ${args.linkId}`)
   }
 


### PR DESCRIPTION
Going through this code confused me a little at first, because the purpose of using the 'linkExists' variable is to see if that particular user has already voted on a particular link. So it is not to check if the link itself exists. Additionally, the error thrown specifies that the user has already voted for the link. So I think it would clear things up if that variable was named 'voteExists' instead. I could be misunderstanding something here, but this is how I understood the code.