### PR TITLE
[Python] Update version of django-graphql-jwt in tutorial

### DIFF
--- a/content/backend/graphql-python/1-getting-started.md
+++ b/content/backend/graphql-python/1-getting-started.md
@@ -39,7 +39,7 @@ The tool used to manage Python packages is `pip`, which should be available with
 With the virtual environment activated, run the following commands:
 
 ```bash
-pip install django==2.1.4 graphene-django==2.2.0 django-filter==2.0.0 django-graphql-jwt==0.1.5
+pip install django==2.1.4 graphene-django==2.2.0 django-filter==2.0.0 django-graphql-jwt==0.2.1
 django-admin startproject hackernews
 cd hackernews
 python manage.py migrate


### PR DESCRIPTION
I had an issue where I received the following error when doing the Authentication step of the Python GraphQL tutorial.

```Internal Server Error: /graphql/
Traceback (most recent call last):
  File "/Users/***/projects/graphql/venv/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/Users/***/projects/graphql/venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/***/projects/graphql/venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 124, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/***/projects/graphql/venv/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/***/projects/graphql/venv/lib/python3.7/site-packages/django/views/generic/base.py", line 62, in view
    self = cls(**initkwargs)
  File "/Users/***/projects/graphql/venv/lib/python3.7/site-packages/graphene_django/views.py", line 88, in __init__
    self.middleware = list(instantiate_middleware(middleware))
  File "/Users/***/projects/graphql/venv/lib/python3.7/site-packages/graphene_django/views.py", line 48, in instantiate_middleware
    yield middleware()
TypeError: __init__() missing 1 required positional argument: 'get_response'
```
Updateing django-graphql-jwt seems to have resolved this and allowed me to move past the Authentication part of the tutorial.

