### PR TITLE
rename linkExists

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -291,11 +291,11 @@ async function vote(parent, args, context, info) {
   const userId = getUserId(context)
 
   // 2
-  const linkExists = await context.prisma.$exists.vote({
+  const voteExists = await context.prisma.$exists.vote({
     user: { id: userId },
     link: { id: args.linkId },
   })
-  if (linkExists) {
+  if (voteExists) {
     throw new Error(`Already voted for link: ${args.linkId}`)
   }
 


### PR DESCRIPTION
I believe this is cleaner since we are testing whether the vote exists and not the link