### PR TITLE
Fixed IDs incrementation in the example

### DIFF
--- a/content/backend/graphql-js/3-a-simple-mutation.md
+++ b/content/backend/graphql-js/3-a-simple-mutation.md
@@ -115,7 +115,7 @@ const resolvers = {
     // 2
     post: (parent, args) => {
        const link = {
-        id: `link-${idCount++}`,
+        id: `link-${idCount}`,
         description: args.description,
         url: args.url,
       }


### PR DESCRIPTION
Issue:

`id: link-${idCount++}`


Using the current implementation the generated IDs will be :
```
id-1
id-3 
id-5
and so on
```
because **links.push(link)** will increase the **idCount** (by default) :) so no need to re-increment!

Cheers
