### PR TITLE
remove graphcool legacy notice

### DIFF
--- a/content/frontend/vue-apollo/0-introduction.md
+++ b/content/frontend/vue-apollo/0-introduction.md
@@ -10,8 +10,6 @@ correctAnswer: 2
 
 ### Overview
 
-> **NOTE**: This tutorial uses the [legacy](https://www.graph.cool/docs/reference/service-definition/legacy-console-projects-aemieb1aev) version of [Graphcool](https://www.graph.cool/) and will be updated soon to use the new [Graphcool Framework](https://blog.graph.cool/introducing-the-graphcool-framework-d9edab2a7816). The CLI commands mentioned in this tutorial are outdated, you can read more about the new CLI [here](https://www.graph.cool/docs/reference/cli/overview-kie1quohli/). If you still want to go through this tutorial, you can install the old version of the CLI using `npm install -g graphcool@0.4`.
-
 In the previous tutorials, you learned about major concepts and benefits of GraphQL. Now is the time to get your hands dirty and start out with an actual project!
 
 You're going to build a simple clone of [Hackernews](https://news.ycombinator.com/). The final product can be viewed [here](http://vue-apollo-hn.surge.sh/). Here's a list of the features the app will have:


### PR DESCRIPTION
Updates for the existing Vue-apollo tutorial

WIP. Current known tasks:

- [ ] remove legacy notices
- [ ] update to `1-getting-started.md` to use graphcool framework
 - [ ] update filepaths in all pages to use filepaths from graphcool framework

closes #785 