### PR TITLE
[Correction]: Union types are disjoint and ignore common implementations

### DIFF
--- a/content/graphql/advanced/2-more-graphql-concepts.md
+++ b/content/graphql/advanced/2-more-graphql-concepts.md
@@ -212,12 +212,13 @@ The answer to this is called _conditional fragments_:
 ```graphql(nocopy)
 {
   allPersons {
-    name # works for `Adult` and `Child`
     ... on Child {
+      name
       school
     }
     ... on Adult {
-       work
+      name
+      work
     }
   }
 }


### PR DESCRIPTION
This example is incorrect. A union type represents a set of possible _disjoint_ types and doesn't allow shared fields.

Examples:
- [GraphQL Spec](https://graphql.github.io/graphql-spec/June2018/#sec-Unions)
- [Apollo Implementation](https://www.apollographql.com/docs/apollo-server/features/unions-interfaces/)