### PR TITLE
Bearer is no more needed in for Authorization

### DIFF
--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -485,7 +485,7 @@ From the server's response, copy the authentication `token` and open another tab
 
 ```json
 {
-  "Authorization": "Bearer __TOKEN__"
+  "Authorization": "__TOKEN__"
 }
 ```
 


### PR DESCRIPTION
In `utils.js` file is string `Bearer` replaced with empty string. Later in tutorial when user should input token into HTTP Header the word `Bearer` is displayed  again. That is incorrect.

From:
```json
{
  "Authorization": "Bearer __TOKEN__"
}
```

To:
```json
{
  "Authorization": "__TOKEN__"
}
```