### PR TITLE
Corrected schema.graphql path in index.js

### DIFF
--- a/content/backend/graphql-js/3-a-simple-mutation.md
+++ b/content/backend/graphql-js/3-a-simple-mutation.md
@@ -81,7 +81,7 @@ First, entirely delete the definition of the `typeDefs` constant - it's not need
 
 ```js{2}(path="../hackernews-node/src/index.js)
 const server = new GraphQLServer({
-  typeDefs: './src/schema.graphql',
+  typeDefs: './schema.graphql',
   resolvers,
 })
 ```


### PR DESCRIPTION
Since both the schema and index files are in the same directory, path for the typeDefs should be './schema.graphql'