### PR TITLE
Update 7-filtering.md

### DIFF
--- a/content/backend/graphql-ruby/7-filtering.md
+++ b/content/backend/graphql-ruby/7-filtering.md
@@ -83,6 +83,12 @@ class Resolvers::LinksSearch
 end
 ```
 
+In order to get this to work, you'll need to add the following line to the `Link` model.
+
+```ruby(path=".../graphql-ruby/app/models/link.rb")
+scope :like, ->(field, value) { where arel_table[field].matches("%#{value}%") }
+```
+
 </Instruction>
 
 This resolver contains all logic related to find links. Over time you can add more rules.
@@ -164,13 +170,6 @@ You can run the tests with the following command:
 ```bash
 bundle exec rails test
 ```
-
-In order to get it to pass, you'll need to add the following line to the `Link` model.
-
-```ruby(path=".../graphql-ruby/app/models/link.rb")
-scope :like, ->(field, value) { where arel_table[field].matches("%#{value}%") }
-```
-
 
 </Instruction>
 


### PR DESCRIPTION
When attempting using the `LinksSearch::Resolver` I kept receiving an error about an undefined method `like` for the ActiveRecordRelation of Links. To fix that, I ended up modifying the scope assignments to be along the lines of `scope.where('description LIKE ?', "%#{value[:description_contains]}%") if value[:description_contains]`. After fixing that and moving forward onto the next parts of this portion of the tutorial, I noticed there was a section about adding the `like` scope to the Link model all the way at the bottom of the page. To prevent this from happening to someone else it would be great to move that block about adding the `like` scope higher up on the page where it's implemented.