### PR TITLE
[Apollo] Update App.js code to include BrowserRouter

### DIFF
--- a/content/frontend/react-apollo/7-filtering-searching-the-list-of-links.md
+++ b/content/frontend/react-apollo/7-filtering-searching-the-list-of-links.md
@@ -69,17 +69,19 @@ Now add the `Search` component as a new route to the app. Open `App.js` and upda
 ```js{10}(path=".../hackernews-react-apollo/src/components/App.js")
 render() {
   return (
-    <div className='center w85'>
-      <Header />
-      <div className='ph3 pv1 background-gray'>
-        <Switch>
-          <Route exact path='/' component={LinkList} />
-          <Route exact path='/create' component={CreateLink} />
-          <Route exact path='/login' component={Login} />
-          <Route exact path='/search' component={Search} />
-        </Switch>
+    <BrowserRouter>
+      <div className='center w85'>
+        <Header />
+        <div className='ph3 pv1 background-gray'>
+          <Switch>
+            <Route exact path='/' component={LinkList} />
+            <Route exact path='/create' component={CreateLink} />
+            <Route exact path='/login' component={Login} />
+            <Route exact path='/search' component={Search} />
+          </Switch>
+        </div>
       </div>
-    </div>
+    </BrowserRouter>
   )
 }
 ```


### PR DESCRIPTION
This was added in a previous lesson, but omitted in this step for implementing Search. Failure to provide BrowserRouter throws the error `Error: Invariant failed: You should not use <withRouter(Header) /> outside a <Router>`