### PR TITLE
Ensure the correct category is highlighted when a backend stack item …

### DIFF
--- a/src/components/home/Chooser.tsx
+++ b/src/components/home/Chooser.tsx
@@ -379,7 +379,7 @@ export default class Chooser extends React.Component<Props, State> {
     if (index < 0 || index > Object.keys(this.props.mds).length) {
       return
     }
-    const selectedCategoryIndex = index > 5 ? 1 : 0
+    const selectedCategoryIndex = index > FRONTEND_TUTORIALS_COUNT ? 1 : 0
     this.setState({ selectedIndex: index, selectedCategoryIndex })
   }
 


### PR DESCRIPTION
…is selected.

The category selector logic was hard coded to look for a value exceeding '5' instead of looking for a value exceeding the 'FRONTEND_TUTORIALS_COUNT'. By swapping out the hard coded value we've resolved the visual bug (not seeing the correct category selector highlighted for most backend tutorials) and future proofed it against changing amounts of tutorials. 