### PR TITLE
graphql-python: Corrected typo (`MIDDLEWARE` => `MIDDLEWARES`)

### DIFF
--- a/content/backend/graphql-python/4-authentication.md
+++ b/content/backend/graphql-python/4-authentication.md
@@ -137,7 +137,7 @@ In the `hackernews/settings.py` file, under the `GRAPHENE` variable, add a new `
 GRAPHENE = {
     'SCHEMA': 'hackernews.schema.schema',
     # Add the line below
-    'MIDDLEWARE': [
+    'MIDDLEWARES': [
         'graphql_jwt.middleware.JSONWebTokenMiddleware',
     ],
 }


### PR DESCRIPTION
Caused a compilation error on loading.