### PR TITLE
Fix scrolling on mobile and MobileMenu content

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import Header from './Header'
 import Overlay from './Overlay'
 import Search from './Search/Search'
-import { Step } from '../types'
+import { MarkdownRemark, Step } from '../types'
 import MobileMenu from './MobileMenu'
 import OverviewVideoModal from './OverviewVideoModal'
 import Logo from './Logo'
@@ -10,12 +10,13 @@ import '../utils/polyfill'
 
 interface Props {
   children?: JSX.Element
+  post?: MarkdownRemark
   history: any
   steps: { [key: string]: Step[] }
   location: any
 }
 
-export default function App({ children, history, steps, location }: Props) {
+export default function App({ children, history, steps, post, location }: Props) {
   return (
     <div>
       <style jsx={true} global={true}>{`
@@ -230,7 +231,7 @@ export default function App({ children, history, steps, location }: Props) {
       <Overlay />
       <OverviewVideoModal />
       <Search history={history} location={location} />
-      <MobileMenu steps={steps} location={location} />
+      <MobileMenu steps={steps} post={post} location={location} />
       <Header steps={steps} location={location} />
       <div className="mobile-logo">
         <Logo />

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { Step } from '../types'
+import { MarkdownRemark, Step } from '../types'
 import Icon from 'graphcool-styles/dist/components/Icon/Icon'
 import * as cn from 'classnames'
 import Sidebar from './Tutorials/Sidebar'
 
 interface Props {
   steps: { [key: string]: Step[] }
+  post?: MarkdownRemark
   location: any
 }
 
@@ -89,6 +90,7 @@ export default class MobileMenu extends React.Component<Props, State> {
           <Sidebar
             steps={steps}
             location={location}
+            post={this.props.post}
             onClickLink={this.toggleMenu}
           />
           <div className="oval" onClick={this.toggleMenu} />

--- a/src/templates/Tutorials.tsx
+++ b/src/templates/Tutorials.tsx
@@ -35,6 +35,7 @@ class Tutorials extends React.Component<Props, null> {
       <App
         history={this.props.history}
         steps={steps}
+        post={post}
         location={this.props.location}
       >
         <div className="tutorials">

--- a/src/templates/Tutorials.tsx
+++ b/src/templates/Tutorials.tsx
@@ -44,9 +44,13 @@ class Tutorials extends React.Component<Props, null> {
             }
             .left-container {
               @p: .bbox, .flexAuto;
-              height: calc(100vh - 68px);
-              overflow-y: scroll; /* has to be scroll, not auto */
-              -webkit-overflow-scrolling: touch;
+            }
+            @media (min-width: 1051px) {
+              .left-container {
+                height: calc(100vh - 68px);
+                overflow-y: scroll; /* has to be scroll, not auto */
+                -webkit-overflow-scrolling: touch;
+              }
             }
           `}</style>
           <div


### PR DESCRIPTION
- Scrolling wasn't really working on iOS Safari, since the nested scroll views throw it off. We don't actually need the scrolling to be present on mobile since the right sidebar goes away
- The `MobileMenu` wasn't displaying the correct `Sidebar` content, since it wasn't receiving a `post` prop that it could pass on to `Sidebar`

cc @nikolasburk: Hope that makes sense 👍  Just saw that this was broken and that the fix was quite minor