### PR TITLE
Remove instructions for post-deploy prisma hook

### DIFF
--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -52,33 +52,7 @@ prisma deploy
 
 </Instruction>
 
-This now updated the Prisma API. You also need to update the auto-generated Prisma client so that it can expose CRUD methods for the newly added `User` model.
-
-<Instruction>
-
-In the same directory, run the following command:
-
-```bash(path=".../hackernews-node")
-prisma generate
-```
-
-</Instruction>
-
-Right now, it is a bit annoying that you need to explicitly run `prisma generate` every time you're migrating your database with `prisma deploy`. To make that easier in the future, you can configure a [post-deployment hook](https://www.prisma.io/docs/prisma-cli-and-configuration/prisma-yml-5cy7/#hooks-optional) that gets invoked every time after you ran `prisma deploy`.
-
-<Instruction>
-
-Add the following lines to the end of your `prisma.yml`:
-
-```yml(path=".../hackernews-node/prisma/prisma.yml")
-hooks:
-  post-deploy:
-    - prisma generate
-```
-
-</Instruction>
-
-The Prisma client will now automatically be regenerated upon a datamodel change. 
+This now updated the Prisma API. The Prisma client is generated automatically after running `prisma deploy`, exposing all the CRUD methods for the newly added User model.
 
 ### Extending the GraphQL schema
 


### PR DESCRIPTION
I was following along with the post-deploy instructions when I noticed this in the CLI

> Warning: The `prisma generate` command was executed twice. Since Prisma 1.31, the Prisma client is generated automatically after running `prisma deploy`. It is not necessary to generate it via a `post-deploy` hook any more, you can therefore remove the hook if you do not need it otherwise.

Seems like this would be worth removing to keep the tutorial up to date with the current state of tooling.