### PR TITLE
update django-graphql-jwt

### DIFF
--- a/content/backend/graphql-python/1-getting-started.md
+++ b/content/backend/graphql-python/1-getting-started.md
@@ -39,7 +39,7 @@ The tool used to manage Python packages is `pip`, which should be available with
 With the virtual environment activated, run the following commands:
 
 ```bash
-pip install django==2.1.4 graphene-django==2.2.0 django-filter==2.0.0 django-graphql-jwt==0.1.5
+pip install django==2.1.4 graphene-django==2.2.0 django-filter==2.0.0 django-graphql-jwt==0.2.1
 django-admin startproject hackernews
 cd hackernews
 python manage.py migrate


### PR DESCRIPTION
For me, django-graphql-jwt version 0.1.5 threw some error in middleware, and since requirements.txt has version 0.2.1, i thought to sync with readme.
Link to requirements: https://github.com/howtographql/graphql-python/blob/master/requirements.txt#L3