### PR TITLE
Fix typo: add missing article.

### DIFF
--- a/content/graphql/advanced/3-tooling-and-ecosystem.md
+++ b/content/graphql/advanced/3-tooling-and-ecosystem.md
@@ -127,6 +127,6 @@ A lot of tools available in the GraphQL ecosystem use the introspection system t
 
 ## GraphQL Playground
 
-[GraphQL Playground](https://github.com/graphcool/graphql-playground) is powerful "GraphQL IDE" for interactively working with a GraphQL API. It features an editor for GraphQL queries, mutations and subscriptions, equipped with autocompletion and validation as well as a documentation explorer to quickly visualize the structure of a schema (powered by introspection). It also can display your query history or lets you work with multiple GraphQL APIs side-by-side. It also seamlessly integrates with [`graphql-config`](https://github.com/graphcool/graphql-config).
+[GraphQL Playground](https://github.com/graphcool/graphql-playground) is a powerful "GraphQL IDE" for interactively working with a GraphQL API. It features an editor for GraphQL queries, mutations and subscriptions, equipped with autocompletion and validation as well as a documentation explorer to quickly visualize the structure of a schema (powered by introspection). It also can display your query history or lets you work with multiple GraphQL APIs side-by-side. It also seamlessly integrates with [`graphql-config`](https://github.com/graphcool/graphql-config).
 
 It is an incredibly powerful tool for development. It allows you to debug and try queries on a GraphQL server without having to write plain GraphQL queries over `curl`, for example.


### PR DESCRIPTION
It appears that an article is missing before the word **powerful**. This PR adds the missing article **a**.

```diff
-GraphQL Playground is powerful "GraphQL IDE" [...]
+GraphQL Playground is a powerful "GraphQL IDE" [...]
```