### PR TITLE
Fix incorrect language classification

### DIFF
--- a/content/backend/graphql-js/1-getting-started.md
+++ b/content/backend/graphql-js/1-getting-started.md
@@ -183,7 +183,7 @@ At the core of every GraphQL API, there is a GraphQL schema. So, let's quickly t
 
 > **Note**: In this tutorial, we'll only scratch the surface of this topic. If you want to go a bit more in-depth and learn more about the GraphQL schema as well as its role in a GraphQL API, be sure to check out [this](https://blog.graph.cool/graphql-server-basics-the-schema-ac5e2950214e) excellent article.
 
-GraphQL schemas are usually written in the GraphQL [Schema Definition Language](https://blog.graph.cool/graphql-sdl-schema-definition-language-6755bcb9ce51) (SDL). The SDL has a type system that allows to define data structures (just like other strongly typed programming languages such as Java, TypeScript, Swift, Go, ...).
+GraphQL schemas are usually written in the GraphQL [Schema Definition Language](https://blog.graph.cool/graphql-sdl-schema-definition-language-6755bcb9ce51) (SDL). The SDL has a type system that allows to define data structures (just like other statically typed programming languages such as Java, TypeScript, Swift, Go, ...).
 
 But how does that help in defining the API for a GraphQL server? Every GraphQL schema has three special _root types_, these are called `Query`, `Mutation` and `Subscription`. The root types correspond to the three operation types offered by GraphQL: queries, mutations and subscriptions. The fields on these root types are called _root field_ and define the available API operations.
 


### PR DESCRIPTION
The author confused statically typed languages with strongly typed languages.

Language classification can be depicted as a 4 grid matrix:

<img width="790" alt="Screen Shot 2020-04-10 at 3 50 42 PM" src="https://user-images.githubusercontent.com/10621548/79018939-11ce9d00-7b43-11ea-8c47-e1354f3bc2b4.png">
