### PR TITLE
Omit password from resolver functions

### DIFF
--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -160,9 +160,9 @@ Open `Mutation.js` and add the new `login` and `signup` resolvers (you'll add th
 ```js(path=".../hackernews-node/src/resolvers/Mutation.js")
 async function signup(parent, args, context, info) {
   // 1
-  const password = await bcrypt.hash(args.password, 10)
+  const hashedPassword = await bcrypt.hash(args.password, 10)
   // 2
-  const {password, ...user} = await context.prisma.createUser({ ...args, password })
+  const {password, ...user} = await context.prisma.createUser({ ...args, password: hashedPassword })
 
   // 3
   const token = jwt.sign({ userId: user.id }, APP_SECRET)
@@ -182,7 +182,7 @@ async function login(parent, args, context, info) {
   }
 
   // 2
-  const valid = await bcrypt.compare(args.password, user.password)
+  const valid = await bcrypt.compare(args.password, password)
   if (!valid) {
     throw new Error('Invalid password')
   }

--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -162,7 +162,7 @@ async function signup(parent, args, context, info) {
   // 1
   const password = await bcrypt.hash(args.password, 10)
   // 2
-  const user = await context.prisma.createUser({ ...args, password })
+  const {password, ...user} = await context.prisma.createUser({ ...args, password })
 
   // 3
   const token = jwt.sign({ userId: user.id }, APP_SECRET)
@@ -176,7 +176,7 @@ async function signup(parent, args, context, info) {
 
 async function login(parent, args, context, info) {
   // 1
-  const user = await context.prisma.user({ email: args.email })
+  const {password, ...user} = await context.prisma.user({ email: args.email })
   if (!user) {
     throw new Error('No such user found')
   }
@@ -208,13 +208,13 @@ module.exports = {
 Let's use the good ol' numbered comments again to understand what's going on here - starting with `signup`.
 
 1. In the `signup` mutation, the first thing to do is encrypting the `User`'s password using the `bcryptjs` library which you'll install soon.
-1. The next step is to use the `prisma` client instance to store the new `User` in the database.
+1. The next step is to use the `prisma` client instance to store the new `User` in the database. Note that we use object destructuring to strip away the password from being returned from `signup` in adherance to the graphql schema.
 1. You're then generating a JWT which is signed with an `APP_SECRET`. You still need to create this `APP_SECRET` and also install the `jwt` library that's used here.
 1. Finally, you return the `token` and the `user` in an object that adheres to the shape of an `AuthPayload` object from your GraphQL schema.
 
 Now on the `login` mutation:
 
-1. Instead of _creating_ a new `User` object, you're now using the `prisma` client instance to retrieve the existing `User` record by the `email` address that was sent along as an argument in the `login` mutation. If no `User` with that email address was found, you're returning a corresponding error.
+1. Instead of _creating_ a new `User` object, you're now using the `prisma` client instance to retrieve the existing `User` record by the `email` address that was sent along as an argument in the `login` mutation. If no `User` with that email address was found, you're returning a corresponding error. Just like with `signup`, we strip away the password using object destructuring to conform to the graphql schema.
 1. The next step is to compare the provided password with the one that is stored in the database. If the two don't match, you're returning an error as well.
 1. In the end, you're returning `token` and `user` again.
 


### PR DESCRIPTION
`signup` and `login` resolver functions were leaking passwords. Although, given the graphql schema doesn't actually expose a password field (hence a client couldn't actually get at the password), it's still "good hygiene" to not have your functions expose data that they shouldn't be exposing anyways.