### PR TITLE
Fixed signInUser mutation image.

### DIFF
--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -244,7 +244,7 @@ end
 
 Now, you can get the token by using [GraphiQL](https://github.com/graphql/graphiql):
 
-![](http://i.imgur.com/jmMofgT.png)
+![](https://i.imgur.com/7wYZXgw.png)
 
 <Instruction>
 


### PR DESCRIPTION
Thankyou for very usefull tutorial.

Fixed an small mistake in the sample GraphiQL mutations image.

### Before
The argument for this mutations was `email` instead of `credentials`.

<img width="847" alt="スクリーンショット 2020-04-19 12 29 14" src="https://user-images.githubusercontent.com/11070996/79678750-8daea080-8239-11ea-80d2-9b0b3191e01d.png">

### After
Fixed `email` to `credentials`.

<img width="847" alt="スクリーンショット 2020-04-19 12 34 06" src="https://user-images.githubusercontent.com/11070996/79678805-1594aa80-823a-11ea-8838-67735e9b4be9.png">
