### PR TITLE
Remove outdated banner from home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,6 @@ export default (props: Props) => {
         description={description}
         overrideDescription={overrideDescription}
       />
-      <Banner />
       <Intro steps={steps} location={props.location} />
       <Chooser mds={steps} location={props.location} history={props.history} />
       <WhatWeBuild />


### PR DESCRIPTION
## Description

The *GraphQL Conf* banner on the homepage is currently out of date, as the https://www.graphqlconf.org/ website still only lists information for last year's conference.

I'd like to propose removing the `<Banner />` temporarily but leaving the code so that we can potentially re-use it once it is valid again.

## Sub-Tasks

- [x] Remove `<Banner />`
- [ ] Discuss leaving the underlying code