### PR TITLE
Fix formatting in python tutorial

### DIFF
--- a/content/backend/graphql-python/4-authentication.md
+++ b/content/backend/graphql-python/4-authentication.md
@@ -146,14 +146,14 @@ MIDDLEWARE = [
 
 In the `hackernews/settings.py` file, under the `GRAPHENE` variable, add the following:
 
-'''python(path=".../graphql-python/hackernews/hackernews/settings.py")
+```python(path=".../graphql-python/hackernews/hackernews/settings.py")
 GRAPHENE = {
     'SCHEMA': 'mysite.myschema.schema',
     'MIDDLEWARE': [
         'graphql_jwt.middleware.JSONWebTokenMiddleware',
     ],
 }
-'''
+```
     
 </Instruction>
 


### PR DESCRIPTION
Single quotes (''') were being used instead of ticks (```) in one snippet. Fixed that