### PR TITLE
Fix formatting of GRAPHENE settings section

### DIFF
--- a/content/backend/graphql-python/4-authentication.md
+++ b/content/backend/graphql-python/4-authentication.md
@@ -146,14 +146,14 @@ MIDDLEWARE = [
 
 In the `hackernews/settings.py` file, under the `GRAPHENE` variable, add the following:
 
-'''python(path=".../graphql-python/hackernews/hackernews/settings.py")
+```python(path=".../graphql-python/hackernews/hackernews/settings.py")
 GRAPHENE = {
-    'SCHEMA': 'mysite.myschema.schema',
+    'SCHEMA': 'hackernews.schema.schema',
     'MIDDLEWARE': [
         'graphql_jwt.middleware.JSONWebTokenMiddleware',
     ],
 }
-'''
+```
     
 </Instruction>
 


### PR DESCRIPTION
The code snippet on the GRAPHENE settings in the section "Configuring django-graphql-jwt" did not show up correctly because the code block was surrounded with normal quotes `'` instead of backticks <code>`</code>. This is fixed now and should show up correctly.

Also, the module path for the schema was wrong/did not fit the rest of the tutorial: `'SCHEMA': 'mysite.myschema.schema'` instead of `'SCHEMA': 'hackernews.schema.schema'`. This is also fixed.