### PR TITLE
Fix for #993

### DIFF
--- a/content/backend/graphql-python/5-links-and-voting.md
+++ b/content/backend/graphql-python/5-links-and-voting.md
@@ -1,7 +1,7 @@
 ---
 title: Links and Voting
-question: In which Python class is defined the arguments for a Mutation?
-answers: ["Input", "Query", "Mutation", "Schema"]
+question: In which Python class are the arguments for a Mutation defined?
+answers: ["Arguments", "Query", "Mutation", "Schema"]
 correctAnswer: 0
 description: Enable Users to create Links and to Vote on them
 ---


### PR DESCRIPTION
As discussed in #993  , the `Input` class is not described in this chapter and the question/answer does not correspond with the code examples. The arguments for a mutation in this section are actually defined in the nested `Arguments` class. 
The proposed change reflects this. 

Also, the phrasing of the question was grammatically not ideal and was therefore changed too.