### PR TITLE
Rename `request` to `context`

### DIFF
--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -348,9 +348,9 @@ To make the above operations possible, open `index.js` and adjust the instantiat
 const server = new GraphQLServer({
   typeDefs: './src/schema.graphql',
   resolvers,
-  context: request => {
+  context: context => {
     return {
-      ...request,
+      ...context,
       prisma,
     }
   },


### PR DESCRIPTION
Renamed the context argument to `context` instead of `request` since the context object contains the request and it is confusing if the name of the object is the same as the property.