### PR TITLE
Update 3-a-simple-mutation.md

### DIFF
--- a/content/backend/graphql-js/3-a-simple-mutation.md
+++ b/content/backend/graphql-js/3-a-simple-mutation.md
@@ -81,7 +81,7 @@ First, entirely delete the definition of the `typeDefs` constant - it's not need
 
 ```js{2}(path="../hackernews-node/src/index.js)
 const server = new GraphQLServer({
-  typeDefs: './src/schema.graphql',
+  typeDefs: './schema.graphql',
   resolvers,
 })
 ```


### PR DESCRIPTION
The schema.graphql is in the same folder. Therefore typedefs need not point to './src/schema.graphql' instead point to './schema.graphql'