### PR TITLE
Fixed incorrect grammar in graphql-python/5-linkes.and-voting.md

### DIFF
--- a/content/backend/graphql-python/5-links-and-voting.md
+++ b/content/backend/graphql-python/5-links-and-voting.md
@@ -1,6 +1,6 @@
 ---
 title: Links and Voting
-question: In which Python class is defined the arguments for a Mutation?
+question: In which Python class are the arguments for a Mutation defined?
 answers: ["Input", "Query", "Mutation", "Schema"]
 correctAnswer: 0
 description: Enable Users to create Links and to Vote on them


### PR DESCRIPTION
Not a huge deal, but I updated some incorrect grammar. I changed "In which Python class is defined the arguments for a Mutation" to "In which Python class are the arguments for a mutation defined"