### PR TITLE
Fix broken image URL

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -616,4 +616,4 @@ mutation {
 }
 ```
 
-![](https://imgur.com/cYkqy1j)
+![](https://i.imgur.com/hmqRJws.png)

--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -616,4 +616,4 @@ mutation {
 }
 ```
 
-![](https://i.imgur.com/hmqRJws.png)
+![](https://i.imgur.com/cYkqy1j.png)


### PR DESCRIPTION
Seems like there was an invalid image URL causing the image not to show.

### Before
<img width="964" alt="image" src="https://user-images.githubusercontent.com/24367010/96983108-f55ee480-1517-11eb-8f33-65c9f1c833db.png">

### After
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/24367010/96983337-027bd380-1518-11eb-943a-336642841940.png">
