### PR TITLE
Fix answer to question in Filtering, Pagination & Sorting

### DIFF
--- a/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
+++ b/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
@@ -4,7 +4,7 @@ pageTitle: "GraphQL Filtering, Pagination & Sorting Tutorial with JavaScript"
 description: "Learn how to add filtering and pagination capabilities to a GraphQL API with Node.js, Express & Prisma."
 question: Which arguments are typically used to paginate through a list in the Prisma Client API using limit-offset pagination?
 answers: ["skip & take", "skip & orderBy", "take & where", "where & orderBy"]
-correctAnswer: 1
+correctAnswer: 0
 ---
 
 This is an exciting section of the tutorial where you'll implement some key features of many robust APIs! The goal is to allow clients to constrain the list of `Link` elements returned by the `feed` query by providing filtering and pagination parameters.


### PR DESCRIPTION
question: Which arguments are typically used to paginate through a list in the Prisma Client API using limit-offset pagination?
refers to pagination only, the answer should be 'skip & take' which is index 0 in the array.

**please ignore if I misunderstood the lesson**

this issue has been reported in #1180