### PR TITLE
fix: typo in create-react-app command

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -29,7 +29,7 @@ First, you are going to create the React project! As mentioned in the beginning,
 To create new project, run the command below:
 
 ```bash
-yarn create react-app hackernews-react-apollo
+yarn create-react-app hackernews-react-apollo
 ```
 
 </Instruction>


### PR DESCRIPTION
I was just going through the tutorial and noticed the create react app command was missing a dash. 