### PR TITLE
Fix filename reference typo

### DIFF
--- a/content/backend/graphql-js/4-adding-a-database.md
+++ b/content/backend/graphql-js/4-adding-a-database.md
@@ -58,7 +58,7 @@ touch prisma/schema.prisma
 
 </Instruction>
 
-Remember the GraphQL schema that you've been working with until now? Well, Prisma has a schema, too! You can think of the `prisma.schema` file as a *database schema*. It has three components:
+Remember the GraphQL schema that you've been working with until now? Well, Prisma has a schema, too! You can think of the `schema.prisma` file as a *database schema*. It has three components:
 
 1. **Data source**: Specifies your database connection.
 1. **Generator**: Indicates that you want to genenerate Prisma Client.


### PR DESCRIPTION
First open-source contribution, let's go~! (I hope I'm doing this right...)

The file [`graphql-js/prisma/schema.prisma`](https://github.com/howtographql/graphql-js/blob/master/prisma/schema.prisma) is referenced as `schema.prisma` throughout the rest of this document except for this one typo.