### PR TITLE
Update 4-database.md

### DIFF
--- a/content/backend/graphql-go/4-database.md
+++ b/content/backend/graphql-go/4-database.md
@@ -57,14 +57,22 @@ go-graphql-hackernews
 --------migrations
 ----------mysql
 ```
+
+```
+mkdir -p go-graphql-hackernews/internal/pkg/db/migrations/mysql
+```
+
 Install go mysql driver and golang-migrate packages then create migrations:
 
 <Instruction>
 
 ```
+export PROJ_DIR=($pwd)
 go get -u github.com/go-sql-driver/mysql
-go build -tags 'mysql' -ldflags="-X main.Version=1.0.0" -o $GOPATH/bin/migrate github.com/golang-migrate/migrate/v4/cmd/migrate/
-cd internal/pkg/db/migrations/
+cd $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate
+git checkout v4.1.0
+go build -tags 'mysql' -ldflags="-X main.Version=$(git describe --tags)" -o $GOPATH/bin/migrate $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate
+cd $PROJ_DIR/internal/pkg/db/migrations/
 migrate create -ext sql -dir mysql -seq create_users_table
 migrate create -ext sql -dir mysql -seq create_links_table
 ```


### PR DESCRIPTION
There is an error in the command installing the golang-migrate module.

```
osboxes@osboxes:~/go/src/github.com$ go build -tags 'mysql' -ldflags="-X main.Version=1.0.0" -o $GOPATH/bin/migrate github.com/golang-migrate/migrate/v4/cmd/migrate/
cannot find package "github.com/golang-migrate/migrate/v4/cmd/migrate" in any of:
	/snap/go/6745/src/github.com/golang-migrate/migrate/v4/cmd/migrate (from $GOROOT)
	/home/osboxes/go/src/github.com/golang-migrate/migrate/v4/cmd/migrate (from $GOPATH)
```

The fix is based on readme.md in the module repo: https://github.com/golang-migrate/migrate/tree/master/cmd/migrate