### PR TITLE
Typo in GraphQL-Node Subscription Section, apollo misspelled 

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -51,7 +51,7 @@ Open your `index.js` file where we instantiate the server and add the following 
 
 ```graphql(path=".../hackernews-node/src/index.js)
 // ... previous import statements
-const { PubSub } = require('spollo-server')
+const { PubSub } = require('apollo-server')
 
 const pubsub = new PubSub()
 ```


### PR DESCRIPTION
```javascript
const { PubSub } = require('apollo-server')
```