### PR TITLE
Fix 6-authentication Title in graphql-js and make it reappear in sidebar.

### DIFF
--- a/content/backend/graphql-js/6-authentication.md
+++ b/content/backend/graphql-js/6-authentication.md
@@ -1,4 +1,5 @@
 ---
+title: Authentication 
 pageTitle: "Implementing Authentication in a GraphQL server with Node.js"
 description: "Learn best practices for implementing authentication and authorization with Node.js, Express & Prisma."
 question: "Which HTTP header field carries the authentication token?"


### PR DESCRIPTION
During the last commit of the file,
https://github.com/howtographql/howtographql/commit/4dc5bb217bd0962bfcc19d6e593be9904bafa39e
The Title might have been removed by accident while clearing conflicts.

This has caused the Authentication Section in graphql-js course to disappear.