### PR TITLE
Remove outdated service worker where create-react-app is used.

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -279,6 +279,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './styles/index.css';
 import App from './components/App';
+import reportWebVitals from './reportWebVitals';
 
 // 1
 import {
@@ -306,6 +307,12 @@ ReactDOM.render(
   </ApolloProvider>,
   document.getElementById('root')
 );
+  
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals();
+
 ```
 
 </Instruction>

--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -279,7 +279,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './styles/index.css';
 import App from './components/App';
-import * as serviceWorker from './serviceWorker';
 
 // 1
 import {
@@ -307,7 +306,6 @@ ReactDOM.render(
   </ApolloProvider>,
   document.getElementById('root')
 );
-serviceWorker.unregister();
 ```
 
 </Instruction>

--- a/content/frontend/react-urql/1-getting-started.md
+++ b/content/frontend/react-urql/1-getting-started.md
@@ -99,7 +99,6 @@ Your project structure should now look as follows:
 │   │   └── App.js
 │   ├── index.js
 │   ├── logo.svg
-│   ├── serviceWorker.js
 │   └── styles
 │       ├── App.css
 │       └── index.css

--- a/content/frontend/react-urql/1-getting-started.md
+++ b/content/frontend/react-urql/1-getting-started.md
@@ -99,6 +99,7 @@ Your project structure should now look as follows:
 │   │   └── App.js
 │   ├── index.js
 │   ├── logo.svg
+│   ├── reportWebVitals.js
 │   └── styles
 │       ├── App.css
 │       └── index.css


### PR DESCRIPTION
Service worker code in the default create-react-app template was removed last summer in this PR: https://github.com/facebook/create-react-app/pull/9349 . I ran into this while going through the react react-apollo tutorial. Searching for `serviceWorker ` showed another outdated reference in react-urql. Removing these should avoid confusion for future tutorial users.