### PR TITLE
Update queries and mutations with additional video content

### DIFF
--- a/content/graphql/basics/2-core-concepts.md
+++ b/content/graphql/basics/2-core-concepts.md
@@ -253,10 +253,13 @@ Putting it all together, this is the _full_ schema for all the queries and mutat
 ```graphql(nocopy)
 type Query {
   allPersons(last: Int): [Person!]!
+  allPosts(last: Int): [Post!]!
 }
 
 type Mutation {
   createPerson(name: String!, age: Int!): Person!
+  updatePerson(id: ID!, name: String!, age: String!): Person!
+  deletePerson(id: ID!): Person!
 }
 
 type Subscription {
@@ -264,6 +267,7 @@ type Subscription {
 }
 
 type Person {
+  id: ID!
   name: String!
   age: Int!
   posts: [Post!]!


### PR DESCRIPTION
The third video from `Core Concepts` specifies additional queries and mutations for the *full* schema. However, the transcript doesn't match the video content. I've added the additional info in this PR.