### PR TITLE
Authenticate Method missing from Code Block

### DIFF
--- a/content/backend/graphql-go/6-authentication.md
+++ b/content/backend/graphql-go/6-authentication.md
@@ -107,6 +107,26 @@ func (user *User) Create() {
 	}
 }
 
+func (user *User) Authenticate() bool {
+	statement, err := database.Db.Prepare("select Password from Users WHERE Username = ?")
+	if err != nil {
+		log.Fatal(err)
+	}
+	row := statement.QueryRow(user.Username)
+
+	var hashedPassword string
+	err = row.Scan(&hashedPassword)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false
+		} else {
+			log.Fatal(err)
+		}
+	}
+
+	return CheckPasswordHash(user.Password, hashedPassword)
+}
+
 //HashPassword hashes given password
 func HashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)


### PR DESCRIPTION
Line 145 mentions an "Authenticate" method that is missing from the code block above it. I've copied the Authenticate method from the github repo with the example code for this project and added it t starting at line 110 to the code block just before the method is discussed.