### PR TITLE
Change filename in post to match Node.js project

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -381,7 +381,7 @@ main components:
   - `index.js` is the entry point for our GraphQL server.
 
 From the mentioned files, only the application schema
-defined in `server/src/schema.js` is relevant for you as a
+defined in `server/src/schema.graphql` is relevant for you as a
 frontend developer. This file contains the
 [GraphQL schema](https://www.prisma.io/blog/graphql-server-basics-the-schema-ac5e2950214e)
 which defines all the operations (queries, mutations and


### PR DESCRIPTION
The filename for the GraphQL schema was referred to as src/schema.js and I believe it was supposed to be src/schema.graphql. That's the only schema file in the Node.js backend project.