### PR TITLE
Update 4-adding-a-database.md

### DIFF
--- a/content/backend/graphql-js/4-adding-a-database.md
+++ b/content/backend/graphql-js/4-adding-a-database.md
@@ -48,7 +48,7 @@ Speaking of being productive and building awesome stuff, let's jump back in and 
 First, let's install the Prisma CLI by running the following command in your terminal:
 
 ```bash(path=".../hackernews-node/")
-npm install @prisma/cli --save-dev
+npm install prisma --save-dev
 ```
 
 </Instruction>


### PR DESCRIPTION
Per prisma's cli warnings, `@prisma/cli` has been renamed to `prisma`. Using `@prisma/cli` causes errors during migrations and `npx prisma generate`.

<img width="599" alt="Screen Shot 2021-02-24 at 7 39 05 PM" src="https://user-images.githubusercontent.com/59491167/109085921-9c2adb80-76d8-11eb-8b9e-8c3797fbabc2.png">
