### PR TITLE
Updating 'Queries: Loading Links' answer to `useQuery` instead of `<Query>`

### DIFF
--- a/content/frontend/react-apollo/2-queries-loading-links.md
+++ b/content/frontend/react-apollo/2-queries-loading-links.md
@@ -13,8 +13,8 @@ question:
 answers:
   [
     "Using a higher-order component called 'graphql'",
-    "Using the '<Query />' component and passing GraphQL
-    query as prop",
+    "Using the 'useQuery' hook and passing the GraphQL
+    query as an argument",
     "Using 'fetch' and putting the query in the body of the
     request",
     'Using XMLHTTPRequest and putting the query in the body

--- a/content/frontend/react-apollo/2-queries-loading-links.md
+++ b/content/frontend/react-apollo/2-queries-loading-links.md
@@ -14,7 +14,7 @@ answers:
   [
     "Using a higher-order component called 'graphql'",
     "Using the 'useQuery' hook and passing the GraphQL
-    query as an argument",
+    query document as an argument",
     "Using 'fetch' and putting the query in the body of the
     request",
     'Using XMLHTTPRequest and putting the query in the body


### PR DESCRIPTION
In the content of [this lecture](https://www.howtographql.com/react-apollo/2-queries-loading-links) there's a reference to `useQuery` being used as the way to query the data. However, the knowledge check question mentions the `<Query />` component with `query` prop which is not mentioned during this chapter and I guess is no longer the standard way.