### PR TITLE
Updating 'Mutations: Creating Links' question to useMutation

### DIFF
--- a/content/frontend/react-apollo/3-mutations-creating-links.md
+++ b/content/frontend/react-apollo/3-mutations-creating-links.md
@@ -11,8 +11,7 @@ answers:
   [
     "Only queries can be wrapped with the 'graphql'
     higher-order component",
-    "'<Mutation />' component allow variables,
-    optimisticResponse, refetchQueries, and update as props",
+    "'useMutation' hook provided by Apollo Client is used to send mutations to the GraphQL server",
     "When wrapping a component with a mutation using
     'graphql', Apollo only injects the mutation function
     into the render prop function",


### PR DESCRIPTION
In the content of [this lecture](https://www.howtographql.com/react-apollo/3-mutations-creating-links/) there's a reference to `useMutation` being used as the way to mutate the data. However, the knowledge check question mentions the `<Mutation />` component which is not mentioned during this chapter.