### PR TITLE
Possible incorrect answer for "Connecting The Server and Database with Prisma Client" chapter in the graphql-node tutorial

### DIFF
--- a/content/backend/graphql-js/5-connecting-server-and-database.md
+++ b/content/backend/graphql-js/5-connecting-server-and-database.md
@@ -4,7 +4,7 @@ pageTitle: 'Connecting a Database to a GraphQL Server with Prisma Tutorial'
 description: 'Learn how to add a database to your GraphQL server. The database is accessed using Prisma Client.'
 question: 'What is the purpose of the context argument in GraphQL resolvers?'
 answers: ['It always provides access to a database', 'It carries the query arguments', 'It is used for authentication', 'It lets resolvers communicate with each other']
-correctAnswer: 2
+correctAnswer: 3
 ---
 
 In this section, you're going to learn how to connect your GraphQL server to your database using [Prisma](https://www.prisma.io), which provides the interface to your database. This connection is


### PR DESCRIPTION
Link to tutorial: [https://www.howtographql.com/graphql-js/5-connecting-server-and-database/](https://www.howtographql.com/graphql-js/5-connecting-server-and-database/)

Maybe I'm wrong but I think there's been a mistake here with the MCQ. At the end of the chapter, in the "UNLOCK THE NEXT CHAPTER" section, the correct answer is "It is used for authentication". I believe the correct answer should be "It lets resolvers communicate with each other".

Edit: Added link to tutorial in description and updated PR title to be more verbose