### PR TITLE
update 'graphql' gem version from 1.9.17 to 1.11.6

### DIFF
--- a/content/backend/graphql-ruby/1-getting-started.md
+++ b/content/backend/graphql-ruby/1-getting-started.md
@@ -49,7 +49,7 @@ Now, let's add GraphQL to the server. First, stop the server.
 Open `Gemfile` and add the following dependency to it:
 
 ```ruby(path=".../graphql-ruby/Gemfile")
-gem 'graphql', '1.9.17'
+gem 'graphql', '1.11.6'
 ```
 
 </Instruction>


### PR DESCRIPTION
`bundle exec rails generate graphql:install` fails with graphql version `1.9.17`

https://github.com/rails/spring/issues/590