### PR TITLE
(NodeJS) Vote example userId does not need getUserId

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -157,7 +157,7 @@ Pop over to `Mutation.js` and locate your `post` resolver function, adding the f
 
 ```js{4,11,13}(path=".../hackernews-node/src/resolvers/Mutation.js")
 async function post(parent, args, context, info) {
-  const userId = getUserId(context)
+  const { userId } = context;
 
   const newLink = await context.prisma.link.create({
     data: {


### PR DESCRIPTION
In the vote example, getting userId does not require
getUserId wrapper because it is already called when setting
up the ApolloServer.

Close #1299 