### PR TITLE
Changed name of the Prisma CLI npm package

### DIFF
--- a/content/backend/graphql-js/4-adding-a-database.md
+++ b/content/backend/graphql-js/4-adding-a-database.md
@@ -48,7 +48,7 @@ Speaking of being productive and building awesome stuff, let's jump back in and 
 First, let's install the Prisma CLI by running the following command in your terminal:
 
 ```bash(path=".../hackernews-node/")
-npm install @prisma/cli --save-dev
+npm install prisma --save-dev
 ```
 
 </Instruction>


### PR DESCRIPTION
Resolves #1298. According to [Prisma 2.16.0 release note](https://github.com/prisma/prisma/releases/tag/2.16.0), package `@prisma/cli` has been moved to `prisma`. Trying to install `@prisma/cli` ends up with an error, as mentioned in the issue.