### PR TITLE
Fixed Typo in npm install of prisma cli. @prisma/cli is now just prisma

### DIFF
--- a/content/backend/graphql-js/4-adding-a-database.md
+++ b/content/backend/graphql-js/4-adding-a-database.md
@@ -48,7 +48,7 @@ Speaking of being productive and building awesome stuff, let's jump back in and 
 First, let's install the Prisma CLI by running the following command in your terminal:
 
 ```bash(path=".../hackernews-node/")
-npm install @prisma/cli --save-dev
+npm install prisma --save-dev
 ```
 
 </Instruction>


### PR DESCRIPTION
To install the prisma cli, we now use ```npm install prisma``` instead of ```npm install @prisma/cli```

See npm package here for reference: https://www.npmjs.com/package/@prisma/cli