### PR TITLE
Update 7-subscriptions fix 404 links

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -95,7 +95,7 @@ Just like with queries and mutations, the first step to implement a subscription
 
 Open your application schema and add the `Subscription` type:
 
-```graphql(path=".../graphql-js/blob/master/src/schema.graphql#L28")
+```graphql(path=".../hackernews-node/src/schema.graphql#L28")
 type Subscription {
   newLink: Link
 }
@@ -113,7 +113,7 @@ Next, go ahead and implement the resolver for the `newLink` field. Resolvers for
 
 To adhere to the modular structure of your resolver implementation, first create a new file called `Subscription.js`:
 
-```bash(path=".../hackernews-node)
+```bash(path=".../hackernews-node/src/resolvers/)
 touch src/resolvers/Subscription.js
 ```
 

--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -95,7 +95,7 @@ Just like with queries and mutations, the first step to implement a subscription
 
 Open your application schema and add the `Subscription` type:
 
-```graphql(path=".../graphql-js/blob/master/src/schema.graphql#L28-L31")
+```graphql(path=".../graphql-js/blob/master/src/schema.graphql#L28")
 type Subscription {
   newLink: Link
 }


### PR DESCRIPTION
# Description

On completing `graphql-js` tutorial (which I loved thank you 🚀 ) I noticed 404 on two links pointing to example code.

## Screenshots
![image](https://user-images.githubusercontent.com/210504/113401015-06533200-93a3-11eb-87e6-3971f0ab8464.png)

![image](https://user-images.githubusercontent.com/210504/113401185-474b4680-93a3-11eb-8513-ca05e938199c.png)

## Testing

I tested on http://localhost:8000

### Screenshots of tests

![image](https://user-images.githubusercontent.com/210504/113401363-8a0d1e80-93a3-11eb-90be-3b01b3d98c6c.png)

![image](https://user-images.githubusercontent.com/210504/113401474-af019180-93a3-11eb-83be-036fef06b84b.png)