### PR TITLE
Fix typo in pubsub missing comma

### DIFF
--- a/content/backend/graphql-js/7-subscriptions.md
+++ b/content/backend/graphql-js/7-subscriptions.md
@@ -71,7 +71,7 @@ const server = new ApolloServer({
     return {
       ...req,
       prisma,
-      pubsub
+      pubsub,
       userId:
         req && req.headers.authorization
           ? getUserId(req)


### PR DESCRIPTION
In the example, there is a missing comma in setting up the context.

Closes #1265