### PR TITLE
fix: typo mistake in graphql-node

### DIFF
--- a/src/data/stacks.ts
+++ b/src/data/stacks.ts
@@ -137,7 +137,7 @@ const data: Stack[] = [
     content: {
       title: 'graphql.js',
       description:
-        'Build your own GraphQL server with Node.js, graphql-yoga and Prisma',
+        'Build your own GraphQL server with Node.js, apollo-server and Prisma',
     },
     authorName: 'Robin MacPherson',
     beginnersChoice: true,


### PR DESCRIPTION
The graphql-node (backend track in nodejs) description in home-page track viewer says tutorial uses graphql-yoga but actually uses apollo-server. So fixed the typo.