### PR TITLE
Replace outdated graphcool link #1317

### DIFF
--- a/content/graphql/advanced/5-common-questions.md
+++ b/content/graphql/advanced/5-common-questions.md
@@ -36,7 +36,7 @@ Authentication and authorization are often confused. _Authentication_ describes 
 
 Authentication in GraphQL can be implemented with common patterns such as [OAuth](https://oauth.net/).
 
-To implement authorization, it is [recommended](http://graphql.org/learn/authorization/) to delegate any data access logic to the business logic layer and not handle it directly in the GraphQL implementation. If you want to have some inspiration on how to implement authorization, you can take a look at [Graphcool's permission rules](https://www.graph.cool/docs/reference/auth/overview-ohs4aek0pe).
+To implement authorization, it is [recommended](http://graphql.org/learn/authorization/) to delegate any data access logic to the business logic layer and not handle it directly in the GraphQL implementation. If you want to have some inspiration on how to implement authorization, you can take a look at this blogpost on [how to implement authorization using GraphQL directives](https://www.prisma.io/blog/graphql-directive-permissions-authorization-made-easy-54c076b5368e).
 
 ### How to do Error Handling?
 


### PR DESCRIPTION
Fixes issue #1317

Replace outdated link about authorization.
Link changed from graphcool (page now inaccessible) to a blog post on prisma.