### PR TITLE
Update documentation

### DIFF
--- a/content/backend/graphql-js/4-adding-a-database.md
+++ b/content/backend/graphql-js/4-adding-a-database.md
@@ -45,7 +45,7 @@ Speaking of being productive and building awesome stuff, let's jump back in and 
 
 <Instruction>
 
-First, let's install the Prisma CLI by running the following command in your terminal:
+First, let's install the Prisma CLI and Prisma Client by running the following command in your terminal:
 
 ```bash(path=".../hackernews-node/")
 npm install prisma --save-dev

--- a/content/backend/graphql-js/4-adding-a-database.md
+++ b/content/backend/graphql-js/4-adding-a-database.md
@@ -49,6 +49,7 @@ First, let's install the Prisma CLI by running the following command in your ter
 
 ```bash(path=".../hackernews-node/")
 npm install prisma --save-dev
+npm install @prisma/client
 ```
 
 </Instruction>


### PR DESCRIPTION
Following this tutorial will current throw an error `Error: Cannot find module '@prisma/client'` at the step for running `node src/script.js` on line 222.  This is solved if we make sure to also install `@prisma/client` alongside `prisma` initially.