### PR TITLE
fix broken link for relay docs

### DIFF
--- a/content/backend/graphql-go/9-summary.md
+++ b/content/backend/graphql-go/9-summary.md
@@ -8,5 +8,5 @@ Congratulations on make it to here! You've learned about gqlgen library and some
 ## Further Steps <a name="further-steps"></a>
 If you want to create more complex GrahpQL APIs there are few things you can check out:
 * Implement voting feature and pagination for the app.
-* Read about [Relays](https://relay.dev/docs/guides/graphql-server-specification/).
+* Read about [Relay](https://relay.dev/docs/guides/graphql-server-specification/).
 * don't forget to visit [Learn GraphQL page](https://graphql.org/learn/) to learn more about GraphQL world.

--- a/content/backend/graphql-go/9-summary.md
+++ b/content/backend/graphql-go/9-summary.md
@@ -8,5 +8,5 @@ Congratulations on make it to here! You've learned about gqlgen library and some
 ## Further Steps <a name="further-steps"></a>
 If you want to create more complex GrahpQL APIs there are few things you can check out:
 * Implement voting feature and pagination for the app.
-* Read about [Relays](https://facebook.github.io/relay/docs/en/graphql-server-specification.html).
+* Read about [Relays](https://relay.dev/docs/guides/graphql-server-specification/).
 * don't forget to visit [Learn GraphQL page](https://graphql.org/learn/) to learn more about GraphQL world.


### PR DESCRIPTION
the old link https://facebook.github.io/relay/docs/en/graphql-server-specification.html in summary was redirected to a 404 page