### PR TITLE
docs: Retire deprecated handler methods

### DIFF
--- a/content/backend/graphql-go/4-database.md
+++ b/content/backend/graphql-go/4-database.md
@@ -181,7 +181,7 @@ func main() {
 
 	database.InitDB()
 	database.Migrate()
-	server := handler.New(hackernews.NewExecutableSchema(hackernews.Config{Resolvers: &hackernews.Resolver{}}))
+	server := handler.NewDefaultServer(hackernews.NewExecutableSchema(hackernews.Config{Resolvers: &hackernews.Resolver{}}))
 	router.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	router.Handle("/query", server)
 

--- a/content/backend/graphql-go/4-database.md
+++ b/content/backend/graphql-go/4-database.md
@@ -181,8 +181,8 @@ func main() {
 
 	database.InitDB()
 	database.Migrate()
-	server := handler.GraphQL(hackernews.NewExecutableSchema(hackernews.Config{Resolvers: &hackernews.Resolver{}}))
-	router.Handle("/", handler.Playground("GraphQL playground", "/query"))
+	server := handler.New(hackernews.NewExecutableSchema(hackernews.Config{Resolvers: &hackernews.Resolver{}}))
+	router.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	router.Handle("/query", server)
 
 	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)

--- a/content/backend/graphql-go/6-authentication.md
+++ b/content/backend/graphql-go/6-authentication.md
@@ -269,8 +269,8 @@ func main() {
 
 	database.InitDB()
 	database.Migrate()
-	server := handler.GraphQL(hackernews.NewExecutableSchema(hackernews.Config{Resolvers: &hackernews.Resolver{}}))
-	router.Handle("/", handler.Playground("GraphQL playground", "/query"))
+	server := handler.NewDefaultServer(hackernews.NewExecutableSchema(hackernews.Config{Resolvers: &hackernews.Resolver{}}))
+	router.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	router.Handle("/query", server)
 
 	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)


### PR DESCRIPTION
## Background

Refactoring the handler package deprecated some methods and this tutorial still uses those methods. Thus, this commit retires the following methods and use the new alternatives.

* https://github.com/99designs/gqlgen/blob/5ad012e3d7be1127706b9c8a3da0378df3a98ec1/handler/handler.go#L17
* https://github.com/99designs/gqlgen/blob/5ad012e3d7be1127706b9c8a3da0378df3a98ec1/handler/handler.go#L242

See https://github.com/99designs/gqlgen/pull/885 for more details about the refactor.
