### PR TITLE
Highlight missing lines in 1-getting-started.md

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -253,7 +253,7 @@ the network connections.
 
 Open `src/index.js` and replace the contents with the following:
 
-```js{6-9,11-13,15-18,21-23}(path=".../hackernews-react-apollo/src/index.js")
+```js{6-9,11-13,15-18,21-23,28,30}(path=".../hackernews-react-apollo/src/index.js")
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './styles/index.css';


### PR DESCRIPTION
The React Apollo Getting Started (https://www.howtographql.com/react-apollo/1-getting-started/) highlights the code changes needed to configure it, but it's missing the highlighting for the step 4 lines that change. The step 4 is later described in text after the code snippet (_4. Finally, we render the root component of our React app. The App is wrapped with the higher-order component ApolloProvider that gets passed the client as a prop._) but having the snippet with the code highlighted makes it easier to follow.

## Before
<img width="514" alt="Captura de Pantalla 2021-06-23 a la(s) 4 39 46 p  m" src="https://user-images.githubusercontent.com/2272928/123171877-f008bf80-d441-11eb-8fb0-b87749cfff04.png">

## After 
Preview: https://deploy-preview-1333--howtographql.netlify.app/react-apollo/1-getting-started/

<img width="498" alt="Captura de Pantalla 2021-06-23 a la(s) 5 06 35 p  m" src="https://user-images.githubusercontent.com/2272928/123174232-6a870e80-d445-11eb-9d1c-2deef7c230a1.png">
