### PR TITLE
Corrected links to GraphQL Relay Specification

### DIFF
--- a/content/backend/graphql-python/10-summary.md
+++ b/content/backend/graphql-python/10-summary.md
@@ -15,7 +15,7 @@ If you want to go deeper into GraphQL, here are some must click links:
 * [Learn GraphQL](http://graphql.org/learn/) - learn about GraphQL, how it works, and how to use it.
 * [GraphQL Weekly](https://graphqlweekly.com/) - sign up for an amazing weekly email about GraphQL.
 * [Lessons from 4 Years of GraphQL](https://www.youtube.com/watch?v=zVNrqo9XGOs) - how GraphQL has evolved inside Facebook.
-* [GraphQL Relay Specification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html) - title self descriptive.
+* [GraphQL Relay Specification](https://relay.dev/docs/guides/graphql-server-specification/) - title self descriptive.
 
 Any feedback, please drop me a [tweet](https://twitter.com/jonatasbaldin).
 

--- a/content/backend/graphql-python/9-relay.md
+++ b/content/backend/graphql-python/9-relay.md
@@ -14,7 +14,7 @@ description: Using Relay on Graphene
 
 Basically speaking, it gives every object a global unique identifier, creates a cursor-based pagination structure and introduces the input parameter to mutations.
 
-You can read more about the GraphQL server side considerations in the [GraphQL Relay Specification](https://facebook.github.io/relay/docs/en/graphql-server-specification.html) and in the [Graphene Documentation](http://docs.graphene-python.org/projects/django/en/latest/tutorial-relay/).
+You can read more about the GraphQL server side considerations in the [GraphQL Relay Specification](https://relay.dev/docs/guides/graphql-server-specification/) and in the [Graphene Documentation](http://docs.graphene-python.org/projects/django/en/latest/tutorial-relay/).
 
 ### Relay and Graphene
 Graphene and Graphene Django already comes with the Relay implementation, making your life easier.


### PR DESCRIPTION
Fixes #1335.
GraphQL Relay Specification has been moved to https://relay.dev/docs/guides/graphql-server-specification/.
This pull request fixes only links in graphql-python tutorial. There are probably also broken links in other courses.