### PR TITLE
Update 7-auth-endpoints.md

### DIFF
--- a/content/backend/graphql-go/7-auth-endpoints.md
+++ b/content/backend/graphql-go/7-auth-endpoints.md
@@ -49,7 +49,7 @@ For this mutation, first we have to check if user exists in database and given p
 
 <Instruction>
 
-`internal/users.go`:
+`internal/users/users.go`:
 ```go
 func (user *User) Authenticate() bool {
 	statement, err := database.Db.Prepare("select Password from Users WHERE Username = ?")


### PR DESCRIPTION
## Background

From the context of the document, the file path should be `internal/users/user.go`, which is created through https://www.howtographql.com/graphql-go/5-create-and-retrieve-links/ . 

## Goal

* correct path to users.go under internal directory