### PR TITLE
Explicitly Set GraphQLPlayground as Landing Page

### DIFF
--- a/content/backend/graphql-js/1-getting-started.md
+++ b/content/backend/graphql-js/1-getting-started.md
@@ -98,6 +98,7 @@ Open `src/index.js` and type the following:
 
 ```js(path="../hackernews-node/src/index.js")
 const { ApolloServer } = require('apollo-server');
+const { ApolloServerPluginLandingPageGraphQLPlayground } = require('apollo-server-core'); 
 
 // 1
 const typeDefs = `
@@ -117,6 +118,9 @@ const resolvers = {
 const server = new ApolloServer({
   typeDefs,
   resolvers,
+  plugins: [
+    ApolloServerPluginLandingPageGraphQLPlayground(),
+  ],
 })
 
 server
@@ -137,9 +141,9 @@ All right, let's understand what's going on here by walking through the numbered
 1. The `typeDefs` constant defines your _GraphQL schema_ (more about this in a bit). Here, it defines a simple `Query`
    type with one _field_ called `info`. This field has the type `String!`. The exclamation mark in the type definition
    means that this field is required and can never be `null`.
-1. The `resolvers` object is the actual _implementation_ of the GraphQL schema. Notice how its structure is identical to
+2. The `resolvers` object is the actual _implementation_ of the GraphQL schema. Notice how its structure is identical to
    the structure of the type definition inside `typeDefs`: `Query.info`.
-1. Finally, the schema and resolvers are bundled and passed to `ApolloServer` which is imported from `apollo-server`.
+3. Finally, the schema and resolvers are bundled and passed to `ApolloServer` which is imported from `apollo-server`.
    This tells the server what API operations are accepted and how they should be resolved.
 
 Go ahead and test your GraphQL server!


### PR DESCRIPTION
The Default Landing Page for Apollo Server is now to the welcome page with the option to use the Apollo Studio https://studio.apollographql.com/ For this Tutorial we need to set the graphqlplayground as the landing page: See https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages/