### PR TITLE
Fix typo "migratons" to "migrations"

### DIFF
--- a/content/frontend/react-apollo/1-getting-started.md
+++ b/content/frontend/react-apollo/1-getting-started.md
@@ -490,7 +490,7 @@ file is our SQLite database.
 > **Note**: You are free to use Postgres or MySQL for this tutorial if you
 > prefer. All aspects of the tutorial will still work with those databases.
 
-Next, let's run database migratons and generate Prisma Client.
+Next, let's run database migrations and generate Prisma Client.
 
 <Instruction>
 


### PR DESCRIPTION
This pull request fixes a typo. It replaces "migratons" with "migrations" in `content/frontend/react-apollo/1-getting-started.md`, or _Step 1. Getting Started_ of the front-end React Apollo tutorial.