### PR TITLE
Remove --no-webpack option when generating new phx

### DIFF
--- a/content/backend/graphql-elixir/1-getting-started.md
+++ b/content/backend/graphql-elixir/1-getting-started.md
@@ -35,7 +35,7 @@ You're going to build an app called Community, and you can think of it as a mini
 Use the `phx.new` generator (confirm with `y` when prompted):
 
 ```bash
-mix phx.new community --no-webpack --no-html
+mix phx.new community --no-html
 ```
 
 </Instruction>


### PR DESCRIPTION
As of Phoenix 1.6, the mix generator no longer has a `--no-webpack` option.