### PR TITLE
Update react-router-dom hook syntax

### DIFF
--- a/content/frontend/react-apollo/4-routing.md
+++ b/content/frontend/react-apollo/4-routing.md
@@ -181,24 +181,24 @@ when mutations are performed.
 <Instruction>
 
 Open `CreateLink.js` and update it to include the
-`useHistory` hook from React Router. In the body of the
-function, create a `history` reference and use it within the
+`useNavigate` hook from React Router. In the body of the
+function, create a `navigate` reference and use it within the
 `onCompleted` callback. This callback runs after the
 mutation is completed.
 
-```js{5}(path=".../hackernews-react-apollo/src/components/CreateLink.js")
+```js{2,5,12}(path=".../hackernews-react-apollo/src/components/CreateLink.js")
 // ...
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const CreateLink = () => {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const [createLink] = useMutation(CREATE_LINK_MUTATION, {
     variables: {
       description: formState.description,
       url: formState.url
     },
-    onCompleted: () => history.push('/')
+    onCompleted: () => navigate('/')
   });
   // ...
 };


### PR DESCRIPTION
`useHistory` was replaced by `useNavigate` in `react-router-dom`. Reference [here](https://stackoverflow.com/questions/62861269/attempted-import-error-usehistory-is-not-exported-from-react-router-dom).

Following [Routing](https://www.howtographql.com/react-apollo/4-routing/) today, we can't go forward with the current version of `react-router-dom` without this.

This also highlights two more lines that must be added.