### PR TITLE
Adjusted feed and post resolver functions

### DIFF
--- a/content/backend/graphql-js/5-connecting-server-and-database.md
+++ b/content/backend/graphql-js/5-connecting-server-and-database.md
@@ -110,7 +110,7 @@ Now let's understand how these new resolvers are working!
 The `feed` resolver is implemented as follows:
 
 ```js(path=".../hackernews-node/src/index.js"&nocopy)
-feed: (parent, args, context, info) => {
+feed: (parent, args, context) => {
   return context.prisma.link.findMany()
 },
 ```
@@ -126,7 +126,7 @@ the database.
 The `post` resolver now looks like this:
 
 ```js(path=".../hackernews-node/src/index.js"&nocopy)
-post: (parent, args, context) => {
+post: (parent, args, context, info) => {
   const newLink = context.prisma.link.create({
     data: {
       url: args.url,


### PR DESCRIPTION
The parameters in the `feed` resolver function was NOT supposed to have `info`, while the `post` resolver did. Just did a switch up.

**Visual Changes**
```diff
// line 113
- feed: (parent, args, context, info) => {
+ feed: (parent, args, context) => { 

// line 129
- post: (parent, args, context) => {
+ post: (parent, args, context, info) => {
```