### PR TITLE
graphql-ruby tutorial content: Avoid potentially problematic `bundle update`

### DIFF
--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -57,7 +57,7 @@ gem 'bcrypt', '~> 3.1.13'
 Then run:
 
 ```bash
-bundle update
+bundle install
 ```
 
 </Instruction>


### PR DESCRIPTION
Running `bundle update` would attempt to all the gems in project, potentially causing unwanted side-effects. `bundle install` is all we need to add `bcrypt` and is much less disruptive.