### PR TITLE
Fix unused assigned values

### DIFF
--- a/content/backend/typescript-apollo/3-a-simple-mutation.md
+++ b/content/backend/typescript-apollo/3-a-simple-mutation.md
@@ -49,8 +49,8 @@ export const LinkMutation = extendType({  // 1
                 let idCount = links.length + 1;  // 5
                 const link = {
                     id: idCount,
-                    description: args.description,
-                    url: args.url,
+                    description: description,
+                    url: url,
                 };
                 links.push(link);
                 return link;


### PR DESCRIPTION
Fixes numbered comment 4 utilization

Currently, the object destructuring of `description` and `url` have the warning "assigned but never used"