### PR TITLE
fix typos of "grahpql"

### DIFF
--- a/content/backend/graphql-go/8-logged-in-user-object.md
+++ b/content/backend/graphql-go/8-logged-in-user-object.md
@@ -23,11 +23,11 @@ func (r *mutationResolver) CreateLink(ctx context.Context, input model.NewLink) 
 	// 2
 	link.User = user
 	linkID := link.Save()
-	grahpqlUser := &model.User{
+	graphqlUser := &model.User{
 		ID:   user.ID,
 		Name: user.Username,
 	}
-	return &model.Link{ID: strconv.FormatInt(linkID, 10), Title:link.Title, Address:link.Address, User:grahpqlUser}, nil
+	return &model.Link{ID: strconv.FormatInt(linkID, 10), Title:link.Title, Address:link.Address, User:graphqlUser}, nil
 }
 ```
 
@@ -48,11 +48,11 @@ func (r *queryResolver) Links(ctx context.Context) ([]*model.Link, error) {
 	var dbLinks []links.Link
 	dbLinks = links.GetAll()
 	for _, link := range dbLinks{
-		grahpqlUser := &model.User{
+		graphqlUser := &model.User{
 			ID:   link.User.ID,
 			Name: link.User.Username,
 		}
-		resultLinks = append(resultLinks, &model.Link{ID: link.ID, Title: link.Title, Address: link.Address, User: grahpqlUser})
+		resultLinks = append(resultLinks, &model.Link{ID: link.ID, Title: link.Title, Address: link.Address, User: graphqlUser})
 	}
 	return resultLinks, nil
 }

--- a/content/backend/graphql-go/9-summary.md
+++ b/content/backend/graphql-go/9-summary.md
@@ -6,7 +6,7 @@ description: "Summary of building a GraphQL server with GO backend"
 
 Congratulations on make it to here! You've learned about gqlgen library and some Graphql fundamentals. By implementing a HackerNews clone you've learned about queries, mutations, authentication and GraphQL query language. 
 ## Further Steps <a name="further-steps"></a>
-If you want to create more complex GrahpQL APIs there are few things you can check out:
+If you want to create more complex GraphQL APIs there are few things you can check out:
 * Implement voting feature and pagination for the app.
 * Read about [Relay](https://relay.dev/docs/guides/graphql-server-specification/).
 * don't forget to visit [Learn GraphQL page](https://graphql.org/learn/) to learn more about GraphQL world.

--- a/content/frontend/react-relay/7-subscriptions.md
+++ b/content/frontend/react-relay/7-subscriptions.md
@@ -39,7 +39,7 @@ Graphcool generally exposes two different GraphQL APIs whose type definitions sl
 
 Currently, subscriptions are only supported for the Simple API. However, you can still use subscriptions with the Relay API by making some manual adjustments to the `schema.graphql` which you feed into the `relay-compiler`. 
 
-Notice that we already did these manual adjustments for you and you already have them in your project as you imported the project from [this URL](https://graphqlbin.com/hn-relay-full.graphql) in chapter 3. If you're interested in what these changes actually look like, take a look at the `Subscription` type in `schema.grahpql`. 
+Notice that we already did these manual adjustments for you and you already have them in your project as you imported the project from [this URL](https://graphqlbin.com/hn-relay-full.graphql) in chapter 3. If you're interested in what these changes actually look like, take a look at the `Subscription` type in `schema.graphql`. 
 
 ### Configuring the Relay Environment
 


### PR DESCRIPTION
- fix a few typos I found while going through the tutorial