### PR TITLE
fix: improve clarity of vote mutation code sample

### DIFF
--- a/content/backend/typescript-apollo/7-voting-and-scalars.md
+++ b/content/backend/typescript-apollo/7-voting-and-scalars.md
@@ -165,7 +165,7 @@ Implement the `resolve` function for the `vote` mutation:
 import { objectType, extendType, nonNull, intArg } from "nexus";
 import { User } from "@prisma/client";
 
-export const Vote = objectType({  // 1
+export const Vote = objectType({ 
     name: "Vote",
     definition(t) {
         t.nonNull.field("link", { type: "Link" });

--- a/content/backend/typescript-apollo/7-voting-and-scalars.md
+++ b/content/backend/typescript-apollo/7-voting-and-scalars.md
@@ -165,6 +165,14 @@ Implement the `resolve` function for the `vote` mutation:
 import { objectType, extendType, nonNull, intArg } from "nexus";
 import { User } from "@prisma/client";
 
+export const Vote = objectType({  // 1
+    name: "Vote",
+    definition(t) {
+        t.nonNull.field("link", { type: "Link" });
+        t.nonNull.field("user", { type: "User" });
+    },
+});
+
 export const VoteMutation = extendType({
     type: "Mutation",
     definition(t) {


### PR DESCRIPTION
This code sample caused issues for me when I was copying through the tutorial. The vote type is already present in the file from a previous code sample. Excluding it while keeping the code above and below it makes it appear as if the Vote type code has been removed and is no longer present. Adding the Vote type to this sample allows it to be safely copied and pasted without creating errors.