### PR TITLE
Fix typo on Typescript+Apollo tutorial

### DIFF
--- a/content/backend/typescript-apollo/2-a-simple-query.md
+++ b/content/backend/typescript-apollo/2-a-simple-query.md
@@ -325,5 +325,5 @@ The reason that these fields do not need explicit resolver implementations is th
 
 In fact, many other GraphQL libraries will also let you omit _trivial resolvers_ and will just assume that if a resolver isn't provided for a field, that a property of the same name should be read and returned.
 
-> **Note:** To learn more about trivial resolvers, check out the [GrahQL docs](https://graphql.org/learn/execution/#trivial-resolvers).
+> **Note:** To learn more about trivial resolvers, check out the [GraphQL docs](https://graphql.org/learn/execution/#trivial-resolvers).
 


### PR DESCRIPTION
Hello. I was following the tutorial and noticed a small typo in the last note about trivial resolvers. I never contributed to open source projects nor saw any guidelines on the project. Please let me know if I'd need to change anything in this PR.