### PR TITLE
graphql-ruby: fix create_link_test

### DIFF
--- a/content/backend/graphql-ruby/3-mutations.md
+++ b/content/backend/graphql-ruby/3-mutations.md
@@ -117,7 +117,7 @@ require 'test_helper'
 
 class Mutations::CreateLinkTest < ActiveSupport::TestCase
   def perform(user: nil, **args)
-    Mutations::CreateLink.new(object: nil, field: nil, context: {}).resolve(args)
+    Mutations::CreateLink.new(object: nil, field: nil, context: {}).resolve(**args)
   end
 
   test 'create a new link' do


### PR DESCRIPTION
On part 3 of the graphql-ruby tutorial, the code for the `Mutations::CreateLinkTest` class doesn't run.

```
Error:
Mutations::CreateLinkTest#test_create_a_new_link:
ArgumentError: wrong number of arguments (given 1, expected 0)
    app/graphql/mutations/create_link.rb:10:in `resolve'
    test/graphql/mutations/create_link_test.rb:6:in `perform'
    test/graphql/mutations/create_link_test.rb:10:in `block in <class:CreateLinkTest>'
```

This is because the test's `perform` method takes a keyword argument `args`, but doesn't splat it before sending it to `Mutations::CreateLink#resolve`. Because of this, `Mutations::CreateLink#resolve` is receiving a single hash argument when it expects 2 keyword arguments.

```ruby
# Mutations::CreateLinkTest
def perform(user: nil, **args)
  Mutations::CreateLink.new(object: nil, field: nil, context: {}).resolve(args)
end
  
# Mutations::CreateLink
def resolve(description: nil, url: nil)
  Link.create!(description: description, url: url)
end
```

Splatting `args` fixes the problem!

```ruby
# Mutations::CreateLinkTest
def perform(user: nil, **args)
  Mutations::CreateLink.new(object: nil, field: nil, context: {}).resolve(**args)
end
```