### PR TITLE
fix: add skip and take arguments to count

### DIFF
--- a/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
+++ b/content/backend/graphql-js/8-filtering-pagination-and-sorting.md
@@ -305,7 +305,11 @@ async function feed(parent, args, context, info) {
     orderBy: args.orderBy,
   })
 
-  const count = await context.prisma.link.count({ where })
+  const count = await context.prisma.link.count({ 
+    where,
+    skip: args.skip,
+    take: args.take
+  })
 
   return {
     links,


### PR DESCRIPTION
Take pagination parameters into account when calculating the number of records returned from the API.