### PR TITLE
fix: 1-getting-started.md typo

### DIFF
--- a/content/backend/graphql-js/1-getting-started.md
+++ b/content/backend/graphql-js/1-getting-started.md
@@ -193,7 +193,7 @@ field is, right?
 So, what happens if you return `null` instead of the actual informative string in the resolver implementation? Feel free
 to try that out!
 
-In `index.js`, update the the definition of `resolvers` as follows:
+In `index.js`, update the definition of `resolvers` as follows:
 
 ```js{3}(path=".../hackernews-node/src/index.js")
 const resolvers = {


### PR DESCRIPTION
Basically this changes `...update the the definition...` to `...update the definition...`