### PR TITLE
Fix typo in python tutorial for GraphQL

### DIFF
--- a/content/backend/graphql-python/2-queries.md
+++ b/content/backend/graphql-python/2-queries.md
@@ -166,7 +166,7 @@ query {
 }
 ```
 
-You should see a response link this:
+You should see a response like this:
 
 ![Query response](http://i.imgur.com/bND8TCT.png)
 


### PR DESCRIPTION
Fixes typo in the tutorial.