### PR TITLE
fix typo on backend tutorial for typescript-apollo intro

### DIFF
--- a/content/backend/typescript-apollo/0-introduction.md
+++ b/content/backend/typescript-apollo/0-introduction.md
@@ -52,7 +52,7 @@ Then, you're going to add a vote feature.
 
 Afterwards, you're going to learn about custom GraphQL scalars and how to add custom scalars to your application. 
 
-Then, you'll allow the consumers of the API to constrain the list of items they retrieve from the API by adding sorting, filtering and pagination capabalities to it.
+Then, you'll allow the consumers of the API to constrain the list of items they retrieve from the API by adding sorting, filtering and pagination capabilities to it.
 
 Finally you will learn how to create a automatic deployment pipeline for the API to a cloud provider (Heroku) using GitHub Actions.
 


### PR DESCRIPTION
Under "**What this tutorial will cover**" section, corrected the word "_capabalities_" to "_capabilties_".

![image](https://user-images.githubusercontent.com/77599339/179116455-b0c73103-3f06-4b19-8bd9-57b1b74b0dc3.png)
