### PR TITLE
fix-authentication-code-snippets

### DIFF
--- a/content/backend/graphql-ruby/4-authentication.md
+++ b/content/backend/graphql-ruby/4-authentication.md
@@ -184,7 +184,7 @@ require 'test_helper'
 
 class Mutations::CreateUserTest < ActiveSupport::TestCase
   def perform(args = {})
-    Mutations::CreateUser.new(object: nil, field: nil, context: {}).resolve(args)
+    Mutations::CreateUser.new(object: nil, field: nil, context: {}).resolve(**args)
   end
 
   test 'create new user' do
@@ -288,7 +288,7 @@ require 'test_helper'
 
 class Mutations::SignInUserTest < ActiveSupport::TestCase
   def perform(args = {})
-    Mutations::SignInUser.new(object: nil, field: nil, context: { session: {} }).resolve(args)
+    Mutations::SignInUser.new(object: nil, field: nil, context: { session: {} }).resolve(**args)
   end
 
   def create_user


### PR DESCRIPTION
The authentication lesson for graphql in ruby contains an error in the test cases for `CreateUser` and `SignInUser`. The perform methods in this lesson are missing the double splat operator that was used in `CreateLinkTest` for example. 