### PR TITLE
Update 6-authentication.md

### DIFF
--- a/content/backend/typescript-apollo/6-authentication.md
+++ b/content/backend/typescript-apollo/6-authentication.md
@@ -483,7 +483,7 @@ export interface AuthTokenPayload {  // 1
 }
 
 export function decodeAuthHeader(authHeader: String): AuthTokenPayload { // 2
-    const token = authHeader.replace("Bearer ", "");  // 3
+    const token = authHeader.split(' ')[1];  // 3
 
     if (!token) {
         throw new Error("No token found");


### PR DESCRIPTION
Using `split` to obtain the token from the header rather than replace - I encountered many errors with `"invalid token"` before changing this from a `replace` to a `split`