### PR TITLE
Update 2-core-concepts.md

### DIFF
--- a/content/graphql/basics/2-core-concepts.md
+++ b/content/graphql/basics/2-core-concepts.md
@@ -260,7 +260,7 @@ type Query {
 
 type Mutation {
   createPerson(name: String!, age: Int!): Person!
-  updatePerson(id: ID!, name: String!, age: String!): Person!
+  updatePerson(id: ID!, name: String!, age: Int!): Person!
   deletePerson(id: ID!): Person!
 }
 


### PR DESCRIPTION
I notice that in the mutation type the argument "age" is defined as a string, although in the definition of the "Person" type the field type is Int.